### PR TITLE
add installation commands in README

### DIFF
--- a/z3tracer/notebooks/README.md
+++ b/z3tracer/notebooks/README.md
@@ -1,11 +1,28 @@
 # Example notebooks using z3tracer
 
-* See the documentation of [EVCXR](https://github.com/google/evcxr/blob/master/evcxr_jupyter/README.md)
-for detailed instructions on how to install the Rust kernel in Jupyter notebooks.
+## Installing Jupyter notebook and Rust kernel
+* Install JupyterLab and Jupyter Notebook using the following commands:
+```
+pip install jupyterlab
+pip install notebook
+```
+If these commands don't work or if you want to install using `conda` instead, 
+see the documentation of [Jupyter Software](https://jupyter.org/install) for the most up-to-date installation instructions.
 
-* Run `jupyter lab z3tracer/notebooks` and open one example file.
+* Install the Rust kernel in Jupyter notebooks on Mac OS by running the following commands:
+```
+cargo install evcxr_jupyter
+evcxr_jupyter --install
+``` 
+If these commands don't work or if you want to install on a different platform, 
+see the documentation of [EvCxR Jupyter Kernel](https://github.com/google/evcxr/blob/master/evcxr_jupyter/README.md) 
+for the most up-to-date installation instructions.
 
-* Execute each cell step by step (for instance using SHIFT+RET). NOTE: compiling and loading crates may take some time.
+## Running the example notebooks
+
+* Run `jupyter lab z3tracer/notebooks` command from root directory of this repository and open one example file.
+
+* Execute each cell step by step (for instance using SHIFT+RET or the play button at the top panel). NOTE: compiling and loading crates may take some time.
 
 * Examples based on [plotly](https://github.com/igiagkiozis/plotly) may require [additional installation steps](https://igiagkiozis.github.io/plotly/content/fundamentals/jupyter_support.html)
   to make Javascript libraries available to Jupyter notebooks. Eventually, it should look like


### PR DESCRIPTION
This PR adds installation commands for Jupyter notebook and EcCxR Rust kernel to the README of z3tracer to make the instructions more self-contained.