### PR TITLE
[z3tracer] make parser options accessible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +465,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "z3tracer"
 version = "0.9.0"
 dependencies = [
+ "anyhow",
  "smt2parser",
  "structopt",
  "thiserror",

--- a/z3tracer/Cargo.toml
+++ b/z3tracer/Cargo.toml
@@ -20,6 +20,9 @@ structopt = "0.3.12"
 smt2parser = { path = "../smt2parser", version = "0.2.0" }
 thiserror = "1.0.24"
 
+[dev-dependencies]
+anyhow = "1.0.40"
+
 [[bin]]
 name = "z3tracer"
 path = "src/main.rs"

--- a/z3tracer/src/error.rs
+++ b/z3tracer/src/error.rs
@@ -16,9 +16,9 @@ pub enum RawError {
     InvalidInteger(std::num::ParseIntError),
     #[error("Invalid hexadecimal string {0}")]
     InvalidHexadecimal(String),
-    #[error("Unexpected char {0:?} {1:?}")]
+    #[error("Unexpected char or end of input: {0:?} instead of {1:?}")]
     UnexpectedChar(Option<char>, Vec<char>),
-    #[error("Unexpected word {0} {1:?}")]
+    #[error("Unexpected word: {0} instead of {1:?}")]
     UnexpectedWord(String, Vec<&'static str>),
     // Parser
     #[error("Missing identifier")]

--- a/z3tracer/src/lexer.rs
+++ b/z3tracer/src/lexer.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::error::{Error, Position, RawError, RawResult};
-use crate::syntax::{Equality, Ident, Literal, MatchedTerm, QiKey, VarName};
+use crate::{
+    error::{Error, Position, RawError, RawResult},
+    syntax::{Equality, Ident, Literal, MatchedTerm, QiKey, VarName},
+};
 use smt2parser::concrete::Symbol;
 
 use std::collections::BTreeMap;
@@ -203,13 +205,15 @@ where
 
     pub(crate) fn read_end_of_line(&mut self) -> RawResult<()> {
         match self.peek_byte() {
-            None => Ok(()),
             Some(b'\n') => {
                 self.consume_byte();
                 self.skip_spaces();
                 Ok(())
             }
-            Some(c) => Err(RawError::UnexpectedChar(Some(*c as char), vec!['\n'])),
+            c => Err(RawError::UnexpectedChar(
+                c.cloned().map(char::from),
+                vec!['\n'],
+            )),
         }
     }
 

--- a/z3tracer/src/lib.rs
+++ b/z3tracer/src/lib.rs
@@ -4,7 +4,7 @@
 //! This crate provides an experimental parser for Z3 tracing logs obtained by passing
 //! `trace=true proof=true`.
 //!
-//! Currently, this library only supports Z3 v4.8.9.
+//! Currently, this library only supports Z3 v4.8.9
 //!
 //! ```
 //! # use std::str::FromStr;

--- a/z3tracer/src/main.rs
+++ b/z3tracer/src/main.rs
@@ -8,8 +8,9 @@ use z3tracer::{Model, ModelConfig};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+/// Test utility for the parsing of Z3 log files.
 #[derive(Debug, StructOpt)]
-#[structopt(name = "z3tracer", about = "Utility for Z3 tracing log files")]
+#[structopt(name = "z3tracer")]
 struct Options {
     #[structopt(flatten)]
     config: ModelConfig,

--- a/z3tracer/src/model.rs
+++ b/z3tracer/src/model.rs
@@ -5,12 +5,14 @@ use smt2parser::concrete::Symbol;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashSet};
 use structopt::StructOpt;
 
-use crate::error::{RawError, RawResult, Result};
-use crate::lexer::Lexer;
-use crate::parser::{LogVisitor, Parser, ParserConfig};
-use crate::syntax::{
-    Equality, Ident, Literal, MatchedTerm, Meaning, QiKey, QuantInstantiation,
-    QuantInstantiationData, QuantInstantiationKind, Term, VarName, Visitor,
+use crate::{
+    error::{RawError, RawResult, Result},
+    lexer::Lexer,
+    parser::{LogVisitor, Parser, ParserConfig},
+    syntax::{
+        Equality, Ident, Literal, MatchedTerm, Meaning, QiKey, QuantInstantiation,
+        QuantInstantiationData, QuantInstantiationKind, Term, VarName, Visitor,
+    },
 };
 
 // https://github.com/TeXitoi/structopt/issues/333

--- a/z3tracer/src/model.rs
+++ b/z3tracer/src/model.rs
@@ -13,10 +13,14 @@ use crate::syntax::{
     QuantInstantiationData, QuantInstantiationKind, Term, VarName, Visitor,
 };
 
-/// Configuration for the analysis of Z3 traces.
-#[doc(hidden)]
+// https://github.com/TeXitoi/structopt/issues/333
+#[cfg_attr(not(doc), allow(missing_docs))]
+#[cfg_attr(doc, doc = "Configuration for the analysis of Z3 traces.")]
 #[derive(Debug, Default, Clone, StructOpt)]
 pub struct ModelConfig {
+    #[structopt(flatten)]
+    pub parser_config: ParserConfig,
+
     /// Whether to log quantifier instantiations (QIs).
     #[structopt(long)]
     pub display_qi_logs: bool,
@@ -107,11 +111,9 @@ impl Model {
     where
         R: std::io::BufRead,
     {
-        let parser_config = ParserConfig {
-            ignore_invalid_lines: true,
-        };
         let lexer = Lexer::new(path_name, input);
-        Parser::new(parser_config, lexer, self).parse()
+        let config = self.config.parser_config.clone();
+        Parser::new(config, lexer, self).parse()
     }
 
     /// All terms in the model.
@@ -642,8 +644,7 @@ impl LogVisitor for &mut Model {
         Ok(())
     }
 
-    fn tool_version(&mut self, s1: String, s2: String) -> RawResult<()> {
-        RawError::check_that_tool_version_is_supported(&s1, &s2)?;
+    fn tool_version(&mut self, _s1: String, _s2: String) -> RawResult<()> {
         self.processed_logs += 1;
         Ok(())
     }

--- a/z3tracer/src/parser.rs
+++ b/z3tracer/src/parser.rs
@@ -10,11 +10,17 @@ use crate::syntax::{
     QuantInstantiationKind, Term, VarName,
 };
 
+// https://github.com/TeXitoi/structopt/issues/333
+#[cfg_attr(not(doc), allow(missing_docs))]
+#[cfg_attr(doc, doc = "Configuration for the parsing of Z3 traces.")]
 #[derive(Debug, Default, Clone, StructOpt)]
 pub struct ParserConfig {
     /// Whether to ignore lines which don't start with '['.
     #[structopt(long)]
     pub ignore_invalid_lines: bool,
+    /// Whether to skip the check for unsupported Z3 version.
+    #[structopt(long)]
+    pub skip_z3_version_check: bool,
 }
 
 /// Parser for Z3 traces.
@@ -252,6 +258,9 @@ where
             "[tool-version]" => {
                 let s1 = lexer.read_string()?;
                 let s2 = lexer.read_string()?;
+                if !self.config.skip_z3_version_check {
+                    RawError::check_that_tool_version_is_supported(&s1, &s2)?;
+                }
                 state.tool_version(s1, s2)?;
                 lexer.read_end_of_line()?;
                 Ok(true)

--- a/z3tracer/src/parser.rs
+++ b/z3tracer/src/parser.rs
@@ -3,11 +3,13 @@
 
 use structopt::StructOpt;
 
-use crate::error::{RawError, RawResult, Result};
-use crate::lexer::Lexer;
-use crate::syntax::{
-    Equality, Ident, Literal, Meaning, QiKey, QuantInstantiation, QuantInstantiationData,
-    QuantInstantiationKind, Term, VarName,
+use crate::{
+    error::{RawError, RawResult, Result},
+    lexer::Lexer,
+    syntax::{
+        Equality, Ident, Literal, Meaning, QiKey, QuantInstantiation, QuantInstantiationData,
+        QuantInstantiationKind, Term, VarName,
+    },
 };
 
 // https://github.com/TeXitoi/structopt/issues/333
@@ -317,6 +319,8 @@ where
             }
             s if self.config.ignore_invalid_lines && !s.starts_with('[') => {
                 // Ignore lines not starting with '['
+                lexer.read_line()?;
+                lexer.read_end_of_line()?;
                 Ok(true)
             }
             s => Err(RawError::UnknownCommand(s.to_string())),

--- a/z3tracer/tests/data/file4.log
+++ b/z3tracer/tests/data/file4.log
@@ -1,0 +1,5 @@
+[tool-version] Z3 4.8.9
+[mk-app] #1 true
+[mk-app] #2 false
+[mk-app] #1 true
+[mk-app] #2 false


### PR DESCRIPTION
* make parser options `ParserConfig` accessible from CLI tool and existing library API
* revert to not skipping incorrect lines by default in `Model::process`
* make version check the default at the parser level
* add option to skip version check
* fix `--help`: Work around annoying bug with `structopt(flatten)`
* fix endless loop on truncated files when skipping incorrect lines