### PR TITLE
[smt2parser] improve AST rewriter

### DIFF
--- a/smt2parser/src/concrete.rs
+++ b/smt2parser/src/concrete.rs
@@ -187,7 +187,7 @@ pub enum Command {
 }
 
 /// An implementation of [`Smt2Visitor`] that returns concrete syntax values.
-#[derive(Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+#[derive(Default, Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct SyntaxBuilder;
 
 impl ConstantVisitor for SyntaxBuilder {


### PR DESCRIPTION
Use a trait with default implementations (instead of a struct with closures) so that behaviors can be redefined with greater flexibility.