### PR TITLE
[smt2patch] initial commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smt2patch"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "rand",
+ "smt2parser",
+ "structopt",
+]
+
+[[package]]
 name = "smt2proxy"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "smt2parser",
     "smt2proxy",
     "z3tracer",
+    "smt2patch",
 ]
 
 [profile.release]

--- a/smt2patch/Cargo.toml
+++ b/smt2patch/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "smt2patch"
+version = "0.1.0"
+description = "Library and binary tool to patch SMT2 files"
+repository = "https://github.com/facebookincubator/smt2utils"
+documentation = "https://docs.rs/smt2patch"
+authors = ["Mathieu Baudet <mathieubaudet@fb.com>"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+keywords = ["smt", "solver", "smt-lib"]
+categories = ["science"]
+edition = "2018"
+exclude = [
+    # Readme template that doesn't need to be included.
+    "README.tpl",
+]
+
+[dependencies]
+rand = "0.8.0"
+structopt = "0.3.12"
+smt2parser = { path = "../smt2parser", version = "0.3.0" }
+anyhow = "1.0.40"
+
+[[bin]]
+name = "smt2patch"
+path = "src/main.rs"
+test = false

--- a/smt2patch/README.md
+++ b/smt2patch/README.md
@@ -1,0 +1,27 @@
+# smt2patch
+
+[![smt2patch on crates.io](https://img.shields.io/crates/v/smt2patch)](https://crates.io/crates/smt2patch)
+[![Documentation](https://docs.rs/smt2patch/badge.svg)](https://docs.rs/smt2patch/)
+[![License](https://img.shields.io/badge/license-Apache-green.svg)](../LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE-MIT)
+
+`smt2patch` is an experimental binary tool to patch SMT2 files.
+
+The `stm2patch` library provides the command processing functionalities and
+configurations used by the binary tool `smt2patch`.
+
+## Contributing
+
+See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+
+## License
+
+This project is available under the terms of either the [Apache 2.0 license](../LICENSE-APACHE) or the [MIT
+license](../LICENSE-MIT).
+
+<!--
+README.md is generated from README.tpl by cargo readme. To regenerate:
+
+cargo install cargo-readme
+cargo readme > README.md
+-->

--- a/smt2patch/README.tpl
+++ b/smt2patch/README.tpl
@@ -1,0 +1,28 @@
+# {{crate}}
+
+[![smt2proxy on crates.io](https://img.shields.io/crates/v/smt2proxy)](https://crates.io/crates/smt2proxy)
+[![Documentation](https://docs.rs/smt2proxy/badge.svg)](https://docs.rs/smt2proxy/)
+[![License](https://img.shields.io/badge/license-Apache-green.svg)](../LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE-MIT)
+
+`smt2proxy` is an experimental binary tool to intercept and pre-process SMT2
+  commands before there are send to an SMT solver. It acts as a command-line replacement
+  for the SMT solver binary. Currently, only Z3 is supported.
+
+{{readme}}
+
+## Contributing
+
+See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+
+## License
+
+This project is available under the terms of either the [Apache 2.0 license](../LICENSE-APACHE) or the [MIT
+license](../LICENSE-MIT).
+
+<!--
+README.md is generated from README.tpl by cargo readme. To regenerate:
+
+cargo install cargo-readme
+cargo readme > README.md
+-->

--- a/smt2patch/src/lib.rs
+++ b/smt2patch/src/lib.rs
@@ -1,0 +1,251 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The `stm2patch` library provides the SMT2 "patching" functionalities and
+//! configurations used by the binary tool `smt2patch`.
+
+use smt2parser::concrete::*;
+use smt2parser::visitors::{CommandVisitor, TermVisitor};
+use std::str::FromStr;
+use std::{collections::HashSet, io::Write, path::Path};
+use structopt::StructOpt;
+
+/// Configuration for the SMT2 rewriting operations.
+#[derive(Debug, Clone, StructOpt)]
+pub struct RewriterConfig {
+    #[structopt(long, parse(from_str = parse_clauses))]
+    keep_only_clauses: Option<HashSet<String>>,
+
+    #[structopt(long)]
+    get_unsat_core: bool,
+
+    #[structopt(long)]
+    tag_quantifiers: bool,
+}
+
+fn parse_clauses(src: &str) -> HashSet<String> {
+    let src = src.trim();
+    let src = if src.starts_with('(') && src.ends_with('(') {
+        &src[1..src.len() - 1].trim()
+    } else {
+        &src[..]
+    };
+    src.split(' ').map(String::from).collect()
+}
+
+/// State of the SMT2 rewriter.
+#[derive(Debug)]
+pub struct Rewriter {
+    config: RewriterConfig,
+    discarded_options: HashSet<String>,
+    builder: SyntaxBuilder,
+    clause_count: usize,
+    quantifier_count: usize,
+}
+
+const PRODUCE_UNSAT_CORES: &str = "produce-unsat-cores";
+const CLAUSE: &str = "clause!";
+const QUANT: &str = "quant!";
+
+impl Rewriter {
+    pub fn new(config: RewriterConfig, discarded_options: HashSet<String>) -> Self {
+        Self {
+            config,
+            discarded_options,
+            builder: SyntaxBuilder::default(),
+            clause_count: 0,
+            quantifier_count: 0,
+        }
+    }
+
+    fn make_clause_name(&mut self) -> Symbol {
+        let s = format!("{}{}", CLAUSE, self.clause_count);
+        self.clause_count += 1;
+        Symbol(s)
+    }
+
+    fn make_quantifier_name(&mut self) -> Symbol {
+        let s = format!("{}{}", QUANT, self.quantifier_count);
+        self.quantifier_count += 1;
+        Symbol(s)
+    }
+
+    #[inline]
+    fn assert_true() -> Command {
+        Command::Assert {
+            term: Term::QualIdentifier(QualIdentifier::Simple {
+                identifier: Identifier::Simple {
+                    symbol: Symbol("true".to_string()),
+                },
+            }),
+        }
+    }
+
+    fn get_clause_name(term: &Term) -> Option<&Symbol> {
+        match term {
+            Term::Attributes { attributes, .. } => {
+                for (k, v) in attributes {
+                    if &k.0 == "named" {
+                        if let AttributeValue::Symbol(s) = v {
+                            return Some(s);
+                        }
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+}
+
+impl smt2parser::rewriter::Rewriter for Rewriter {
+    type V = SyntaxBuilder;
+
+    fn visitor(&mut self) -> &mut SyntaxBuilder {
+        &mut self.builder
+    }
+
+    fn process_symbol(&mut self, symbol: Symbol) -> Symbol {
+        // Bump clause_count and quantifier_count when needed to avoid
+        // clashes with user-provided symbols.
+        if symbol.0.starts_with(CLAUSE) {
+            if let Ok(i) = usize::from_str(&symbol.0[CLAUSE.len()..]) {
+                self.clause_count = std::cmp::max(self.clause_count, i + 1);
+            }
+        } else if symbol.0.starts_with(QUANT) {
+            if let Ok(i) = usize::from_str(&symbol.0[QUANT.len()..]) {
+                self.clause_count = std::cmp::max(self.clause_count, i + 1);
+            }
+        }
+        symbol
+    }
+
+    fn visit_forall(&mut self, vars: Vec<(Symbol, Sort)>, term: Term) -> Term {
+        let term = if !self.config.tag_quantifiers {
+            term
+        } else {
+            match &term {
+                Term::Attributes { attributes, .. }
+                    if attributes.iter().any(|(k, _)| &k.0 == "qid") =>
+                {
+                    term
+                }
+                _ => {
+                    let name = self.make_quantifier_name();
+                    Term::Attributes {
+                        term: Box::new(term),
+                        attributes: vec![(
+                            Keyword("qid".to_string()),
+                            AttributeValue::Symbol(name),
+                        )],
+                    }
+                }
+            }
+        };
+        let value = self.visitor().visit_forall(vars, term);
+        self.process_term(value)
+    }
+
+    fn visit_assert(&mut self, term: Term) -> Command {
+        let name = Self::get_clause_name(&term);
+        let need_name = self.config.get_unsat_core && name.is_none();
+        let name = name.cloned().unwrap_or_else(|| self.make_clause_name());
+        if let Some(list) = &self.config.keep_only_clauses {
+            if !list.contains(&name.0) {
+                // Discard clause.
+                return Self::assert_true();
+            }
+        }
+        let term = if need_name {
+            Term::Attributes {
+                term: Box::new(term),
+                attributes: vec![(Keyword("named".to_string()), AttributeValue::Symbol(name))],
+            }
+        } else {
+            term
+        };
+        let value = self.visitor().visit_assert(term);
+        self.process_command(value)
+    }
+
+    fn visit_set_option(&mut self, keyword: Keyword, value: AttributeValue) -> Command {
+        if self.discarded_options.contains(&keyword.0) {
+            return Self::assert_true();
+        }
+        let value = self.visitor().visit_set_option(keyword, value);
+        self.process_command(value)
+    }
+
+    fn visit_get_unsat_core(&mut self) -> Command {
+        if self.config.get_unsat_core {
+            // Will be re-added in Patcher.
+            return Self::assert_true();
+        }
+        let value = self.visitor().visit_get_unsat_core();
+        self.process_command(value)
+    }
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct PatcherConfig {
+    #[structopt(flatten)]
+    rewriter_config: RewriterConfig,
+}
+
+/// State of the SMT2 patcher.
+#[derive(Debug)]
+pub struct Patcher {
+    config: PatcherConfig,
+    script: Vec<Command>,
+}
+
+impl Patcher {
+    pub fn new(config: PatcherConfig) -> Self {
+        Self {
+            config,
+            script: Vec::new(),
+        }
+    }
+
+    pub fn read(&mut self, path: &Path) -> std::io::Result<()> {
+        let file = std::io::BufReader::new(std::fs::File::open(path)?);
+        let mut discarded_options = HashSet::new();
+        if self.config.rewriter_config.get_unsat_core {
+            discarded_options.insert(PRODUCE_UNSAT_CORES.to_string());
+        }
+        let rewriter = Rewriter::new(self.config.rewriter_config.clone(), discarded_options);
+        let mut stream = smt2parser::CommandStream::new(file, rewriter);
+        let assert_true = Rewriter::assert_true();
+        for result in &mut stream {
+            match result {
+                Ok(command) if command == assert_true => {}
+                Ok(command)
+                    if self.config.rewriter_config.get_unsat_core
+                        && command == Command::CheckSat =>
+                {
+                    self.script.push(command);
+                    self.script.push(Command::GetUnsatCore);
+                }
+                Ok(command) => {
+                    self.script.push(command);
+                }
+                Err(error) => {
+                    panic!("error:\n --> {}", error.location_in_file(path));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn write(&self, path: &Path) -> std::io::Result<()> {
+        let mut file = std::fs::File::create(path)?;
+        if self.config.rewriter_config.get_unsat_core {
+            // TODO: repeat after resets
+            writeln!(file, "(set-option :{} true)", PRODUCE_UNSAT_CORES)?;
+        }
+        for command in &self.script {
+            writeln!(file, "{}", command)?;
+        }
+        Ok(())
+    }
+}

--- a/smt2patch/src/main.rs
+++ b/smt2patch/src/main.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use structopt::StructOpt;
+
+/// Patch for SMT2 commands. Compatible with the command-line syntax of Z3.
+#[derive(Debug, StructOpt)]
+struct Options {
+    /// Output file
+    #[structopt(long, default_value = "/dev/stdout")]
+    output: std::path::PathBuf,
+
+    #[structopt(flatten)]
+    config: smt2patch::PatcherConfig,
+
+    /// Input file
+    input: std::path::PathBuf,
+}
+
+fn main() -> anyhow::Result<()> {
+    let options = Options::from_args();
+
+    let mut patcher = smt2patch::Patcher::new(options.config);
+    patcher.read(&options.input)?;
+    patcher.write(&options.output)?;
+    Ok(())
+}


### PR DESCRIPTION
Explore a new tool to make changes to an SMT2 file.
Current features include:
* tagging asserts with names and inserting a call to get-unsat-core
* being able to remove clauses not in the unsat core
* tagging quantified expressions with a QID
* setting the weight of quantified expressions

```
cargo run -p smt2patch -- --get-unsat-core FILE | z3 -in | tail -n 1 > unsat_core.txt

cargo run -p smt2patch -- --keep-only-clauses "$(cat unsat_core.txt)" -- FILE | z3 -in

cargo run -p smt2patch -- --tag-quantifiers  FILE | z3 trace=true -in  # z3.log now contains quant!N names

cargo run -p smt2patch -- --set-weights quant!0=100 -- FILE
```

Example of output using `--get-unsat-core` and `--tag-quantifiers`:
```
(set-option :produce-unsat-cores true)
(set-info :smt-lib-version  2.6)
(set-logic ALIA)
(set-info :source  piVC)
(set-info :category  "industrial")
(set-info :status  unsat)
(declare-fun V_9 () Int)
(declare-fun a () (Array Int Int))
(assert (! (let ((?v_0 (and true (>= V_9 0)))) (and (and ?v_0 ?v_0) (and (forall ((?V_7 Int)) (! (=> (and (<= 0 ?V_7) (<= ?V_7 5)) (forall ((?V_8 Int)) (! (let ((?v_1 (store (store a 0 5) 5 7))) (=> (and (<= 0 ?V_8) (<= ?V_8 ?V_7)) (<= (select ?v_1 ?V_8) (select ?v_1 ?V_7)))) :qid quant!0))) :qid quant!1)) (forall ((?V_5 Int)) (! (=> (and (<= 0 ?V_5) (<= ?V_5 5)) (forall ((?V_6 Int)) (! (let ((?v_2 (store (store a 0 1) 5 3))) (=> (and (<= 0 ?V_6) (<= ?V_6 ?V_5)) (<= (select ?v_2 ?V_6) (select ?v_2 ?V_5)))) :qid quant!2))) :qid quant!3))))) :named clause!0))
(check-sat)
(get-unsat-core)
(exit)
```

Original file:
```
(set-info :smt-lib-version 2.6)
(set-logic ALIA)
(set-info :source |piVC|)
(set-info :category "industrial")
(set-info :status unsat)
(declare-fun V_9 () Int)
(declare-fun a () (Array Int Int))
(assert (let ((?v_0 (and true (>= V_9 0)))) (and (and ?v_0 ?v_0) (and (forall ((?V_7 Int)) (=> (and (<= 0 ?V_7) (<= ?V_7 5)) (forall ((?V_8 Int)) (let ((?v_1 (store (store a 0 5) 5 7))) (=> (and (<= 0 ?V_8) (<= ?V_8 ?V_7)) (<= (select ?v_1 ?V_8) (select ?v_1 ?V_7))))))) (forall ((?V_5 Int)) (=> (and (<= 0 ?V_5) (<= ?V_5 5)) (forall ((?V_6 Int)) (let ((?v_2 (store (store a 0 1) 5 3))) (=> (and (<= 0 ?V_6) (<= ?V_6 ?V_5)) (<= (select ?v_2 ?V_6) (select ?v_2 ?V_5)))))))))))
(check-sat)
(exit)
```