### PR TITLE
[smt2parser] Add support for name resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "smt2parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "fst",
  "num",

--- a/smt2parser/Cargo.toml
+++ b/smt2parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smt2parser"
-version = "0.3.0"
+version = "0.4.0"
 description = "Generic parser library for the SMT-LIB-2 format"
 repository = "https://github.com/facebookincubator/smt2utils"
 documentation = "https://docs.rs/smt2parser"

--- a/smt2parser/src/concrete.rs
+++ b/smt2parser/src/concrete.rs
@@ -1181,7 +1181,10 @@ impl std::fmt::Display for Term {
                     term,
                     attributes
                         .iter()
-                        .map(|(key, value)| format!("{}{}", key, value))
+                        .map(|(key, value)| match value {
+                            AttributeValue::None => format!("{}", key),
+                            _ => format!("{} {}", key, value),
+                        })
                         .collect::<Vec<_>>()
                         .join(" "),
                 )

--- a/smt2parser/src/lib.rs
+++ b/smt2parser/src/lib.rs
@@ -32,6 +32,7 @@ extern crate pomelo;
 pub mod concrete;
 mod lexer;
 mod parser;
+pub mod renaming;
 pub mod rewriter;
 pub mod stats;
 pub mod visitors;

--- a/smt2parser/src/parser.rs
+++ b/smt2parser/src/parser.rs
@@ -355,11 +355,11 @@ pomelo! {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::{concrete::*, lexer::Lexer};
 
-    fn parse_tokens<I: IntoIterator<Item = Token>>(tokens: I) -> Result<Command, ()> {
+    pub(crate) fn parse_tokens<I: IntoIterator<Item = Token>>(tokens: I) -> Result<Command, ()> {
         let mut builder = SyntaxBuilder;
         let mut p = Parser::new(&mut builder);
         for token in tokens.into_iter() {

--- a/smt2parser/src/renaming.rs
+++ b/smt2parser/src/renaming.rs
@@ -1,0 +1,310 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Utilities for name resolution and renaming of bound symbols.
+
+use crate::{
+    concrete::*,
+    rewriter::Rewriter,
+    visitors::{Identifier, Index, Smt2Visitor},
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A [`Rewriter`] implementation that converts old-style testers `is-Foo` into a proper indexed identifier `(_ is Foo)`.
+#[derive(Debug, Default)]
+pub struct TesterModernizer<V>(V);
+
+impl<V> TesterModernizer<V> {
+    pub fn new(visitor: V) -> Self {
+        Self(visitor)
+    }
+}
+
+impl<V> Rewriter for TesterModernizer<V>
+where
+    V: Smt2Visitor<QualIdentifier = QualIdentifier, Symbol = Symbol>,
+{
+    type V = V;
+
+    fn visitor(&mut self) -> &mut V {
+        &mut self.0
+    }
+
+    fn visit_simple_identifier(&mut self, value: Identifier<Symbol>) -> QualIdentifier {
+        let value = match value {
+            Identifier::Simple { symbol } if symbol.0.starts_with("is-") => {
+                let is = Symbol("is".to_string());
+                let name = Symbol(symbol.0[3..].to_string());
+                Identifier::Indexed {
+                    symbol: is,
+                    indices: vec![Index::Symbol(name)],
+                }
+            }
+            v => v,
+        };
+        self.0.visit_simple_identifier(value)
+    }
+}
+
+/// A [`Rewriter`] implementation that normalizes local symbols into `x0`, `x1`, etc.
+/// * Normalization applies to all symbols disregarding their usage (datatype, sorts,
+/// functions, variables, etc).
+/// * "Global" symbols (those which don't resolve locally) are ignored.
+#[derive(Debug, Default)]
+pub struct SymbolNormalizer<V> {
+    /// The underlying syntax visitor.
+    visitor: V,
+    /// Track the original name of local symbols.
+    local_symbols: Vec<String>,
+    /// Track symbols that were not resolved (thus ignored).
+    global_symbols: BTreeSet<String>,
+    /// Currently bound symbols.
+    bound_symbols: BTreeMap<String, Vec<usize>>,
+}
+
+const SYMBOL: &str = "x";
+
+impl<V> SymbolNormalizer<V> {
+    pub fn new(visitor: V) -> Self {
+        Self {
+            visitor,
+            local_symbols: Vec::new(),
+            global_symbols: BTreeSet::new(),
+            bound_symbols: BTreeMap::new(),
+        }
+    }
+
+    pub fn get_symbol(idx: usize) -> Symbol {
+        Symbol(format!("{}{}", SYMBOL, idx))
+    }
+
+    fn parse_symbol(s: &Symbol) -> usize {
+        str::parse(&s.0[SYMBOL.len()..]).expect("cannot parse symbol")
+    }
+
+    /// Initial names of all local symbols that were renamed.
+    pub fn local_symbols(&self) -> impl IntoIterator<Item = &String> {
+        &self.local_symbols
+    }
+
+    /// Symbols that failed to resolve locally (e.g. theory defined).
+    pub fn global_symbols(&self) -> impl IntoIterator<Item = &String> {
+        &self.global_symbols
+    }
+}
+
+impl<V> Rewriter for SymbolNormalizer<V>
+where
+    V: Smt2Visitor<Symbol = Symbol>,
+{
+    type V = V;
+
+    fn visitor(&mut self) -> &mut V {
+        &mut self.visitor
+    }
+
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Symbol, String> {
+        let value = self
+            .bound_symbols
+            .get(&value)
+            .map(|v| Self::get_symbol(*v.last().unwrap()))
+            .unwrap_or_else(|| {
+                self.global_symbols.insert(value.clone());
+                Symbol(value)
+            });
+        Ok(self.process_symbol(value))
+    }
+
+    fn visit_fresh_symbol(&mut self, value: String) -> Symbol {
+        let s = Self::get_symbol(self.local_symbols.len());
+        self.local_symbols.push(value);
+        self.process_symbol(s)
+    }
+
+    fn bind_symbol(&mut self, symbol: &Symbol) {
+        let i = Self::parse_symbol(symbol);
+        let value = self.local_symbols[i].clone();
+        self.bound_symbols.entry(value).or_default().push(i);
+    }
+
+    fn unbind_symbol(&mut self, symbol: &Symbol) {
+        use std::collections::btree_map;
+        let i = Self::parse_symbol(symbol);
+        let value = self.local_symbols[i].clone();
+        match self.bound_symbols.entry(value) {
+            btree_map::Entry::Occupied(mut e) => {
+                assert_eq!(e.get_mut().pop().unwrap(), i);
+                if e.get().is_empty() {
+                    e.remove_entry();
+                }
+            }
+            _ => panic!("invalid entry"),
+        }
+    }
+}
+
+#[test]
+fn test_testers() {
+    use crate::{lexer::Lexer, parser::tests::parse_tokens};
+
+    let value = parse_tokens(Lexer::new(&b"(assert (is-Foo 3))"[..])).unwrap();
+    assert!(matches!(
+        value,
+        Command::Assert {
+            term: Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Simple { .. }
+                },
+                ..
+            }
+        }
+    ));
+    assert_eq!(
+        value,
+        value.clone().accept(&mut crate::concrete::SyntaxBuilder)
+    );
+    // Visit with the TesterModernizer this time.
+    let mut builder = TesterModernizer::<SyntaxBuilder>::default();
+    assert!(matches!(
+        value.clone().accept(&mut builder),
+        Command::Assert {
+            term: Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Indexed { .. }
+                },
+                ..
+            }
+        }
+    ));
+}
+
+#[test]
+fn test_declare_datatypes_renaming() {
+    use crate::{lexer::Lexer, parser::tests::parse_tokens};
+
+    let value = parse_tokens(Lexer::new(&b"
+(declare-datatypes (
+    (Type 0)
+    (TypeArray 0)
+)(
+    ((IntType) (VectorType (typeOfVectorType Type)) (StructType (nameOfStructType Name) (typesOfStructType TypeArray)))
+    ((TypeArray (valueOfTypeArray (Array Int Type)) (lengthOfTypeArray Int)))
+))"[..])).unwrap();
+    assert!(matches!(value, Command::DeclareDatatypes { .. }));
+
+    let value2 = parse_tokens(Lexer::new(
+        &b"
+(declare-datatypes (
+    (x0 0)
+    (x1 0)
+)(
+    ((x2) (x3 (x4 x0)) (x5 (x6 Name) (x7 x1)))
+    ((x8 (x9 (Array Int x0)) (x10 Int)))
+))"[..],
+    ))
+    .unwrap();
+    assert!(matches!(value2, Command::DeclareDatatypes { .. }));
+
+    assert_eq!(
+        value,
+        value.clone().accept(&mut crate::concrete::SyntaxBuilder)
+    );
+
+    let mut builder = SymbolNormalizer::<SyntaxBuilder>::default();
+    assert_eq!(value2, value.clone().accept(&mut builder));
+}
+
+#[test]
+fn test_symbol_renaming() {
+    use crate::concrete::*;
+
+    // (assert (let ((x (f x 2))) (= x 3)))
+    let command = Command::Assert {
+        term: Term::Let {
+            var_bindings: vec![(
+                Symbol("x".into()),
+                Term::Application {
+                    qual_identifier: QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("f".into()),
+                        },
+                    },
+                    arguments: vec![
+                        Term::QualIdentifier(QualIdentifier::Simple {
+                            identifier: Identifier::Simple {
+                                symbol: Symbol("x".into()),
+                            },
+                        }),
+                        Term::Constant(Constant::Numeral(num::BigUint::from(2u32))),
+                    ],
+                },
+            )],
+            term: Box::new(Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Simple {
+                        symbol: Symbol("=".into()),
+                    },
+                },
+                arguments: vec![
+                    Term::QualIdentifier(QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("x".into()),
+                        },
+                    }),
+                    Term::Constant(Constant::Numeral(num::BigUint::from(3u32))),
+                ],
+            }),
+        },
+    };
+
+    let mut builder = SymbolNormalizer::<SyntaxBuilder>::default();
+
+    let command2 = command.accept(&mut builder);
+    let command3 = Command::Assert {
+        term: Term::Let {
+            var_bindings: vec![(
+                Symbol("x0".into()),
+                Term::Application {
+                    qual_identifier: QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("f".into()),
+                        },
+                    },
+                    arguments: vec![
+                        Term::QualIdentifier(QualIdentifier::Simple {
+                            identifier: Identifier::Simple {
+                                symbol: Symbol("x".into()),
+                            },
+                        }),
+                        Term::Constant(Constant::Numeral(num::BigUint::from(2u32))),
+                    ],
+                },
+            )],
+            term: Box::new(Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Simple {
+                        symbol: Symbol("=".into()),
+                    },
+                },
+                arguments: vec![
+                    Term::QualIdentifier(QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("x0".into()),
+                        },
+                    }),
+                    Term::Constant(Constant::Numeral(num::BigUint::from(3u32))),
+                ],
+            }),
+        },
+    };
+
+    assert_eq!(command2, command3);
+    assert_eq!(
+        builder.local_symbols().into_iter().collect::<Vec<_>>(),
+        vec!["x"]
+    );
+    assert_eq!(
+        builder.global_symbols().into_iter().collect::<Vec<_>>(),
+        vec!["=", "f", "x"]
+    );
+}

--- a/smt2parser/src/rewriter.rs
+++ b/smt2parser/src/rewriter.rs
@@ -97,9 +97,30 @@ pub trait Rewriter {
     }
 
     // SymbolVisitor
-    fn visit_symbol(&mut self, value: String) -> <Self::V as Smt2Visitor>::Symbol {
-        let value = self.visitor().visit_symbol(value);
+    fn visit_bound_symbol(
+        &mut self,
+        value: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Symbol, String> {
+        let value = self.visitor().visit_bound_symbol(value);
+        value.map(|s| self.process_symbol(s))
+    }
+
+    fn visit_fresh_symbol(&mut self, value: String) -> <Self::V as Smt2Visitor>::Symbol {
+        let value = self.visitor().visit_fresh_symbol(value);
         self.process_symbol(value)
+    }
+
+    fn visit_any_symbol(&mut self, value: String) -> <Self::V as Smt2Visitor>::Symbol {
+        let value = self.visitor().visit_any_symbol(value);
+        self.process_symbol(value)
+    }
+
+    fn bind_symbol(&mut self, symbol: &<Self::V as Smt2Visitor>::Symbol) {
+        self.visitor().bind_symbol(symbol);
+    }
+
+    fn unbind_symbol(&mut self, symbol: &<Self::V as Smt2Visitor>::Symbol) {
+        self.visitor().unbind_symbol(symbol);
     }
 
     // KeywordVisitor
@@ -488,8 +509,24 @@ where
 {
     type T = V::Symbol;
 
-    fn visit_symbol(&mut self, value: String) -> Self::T {
-        self.visit_symbol(value)
+    fn visit_fresh_symbol(&mut self, value: String) -> Self::T {
+        self.visit_fresh_symbol(value)
+    }
+
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, String> {
+        self.visit_bound_symbol(value)
+    }
+
+    fn visit_any_symbol(&mut self, value: String) -> Self::T {
+        self.visit_any_symbol(value)
+    }
+
+    fn bind_symbol(&mut self, symbol: &Self::T) {
+        self.bind_symbol(symbol)
+    }
+
+    fn unbind_symbol(&mut self, symbol: &Self::T) {
+        self.unbind_symbol(symbol)
     }
 }
 

--- a/smt2parser/src/stats.rs
+++ b/smt2parser/src/stats.rs
@@ -23,7 +23,9 @@ pub struct Smt2Counters {
     pub hexadecimal_constant_count: usize,
     pub binary_constant_count: usize,
     pub string_constant_count: usize,
-    pub symbol_count: usize,
+    pub fresh_symbol_count: usize,
+    pub bound_symbol_count: usize,
+    pub any_symbol_count: usize,
     pub keyword_count: usize,
     pub constant_s_expr_count: usize,
     pub symbol_s_expr_count: usize,
@@ -155,9 +157,18 @@ impl ConstantVisitor for Smt2Counters {
 impl SymbolVisitor for Smt2Counters {
     type T = ();
 
-    fn visit_symbol(&mut self, value: String) -> Self::T {
-        self.symbol_count += 1;
+    fn visit_fresh_symbol(&mut self, _value: String) -> Self::T {
+        self.fresh_symbol_count += 1;
+    }
+
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, String> {
+        self.bound_symbol_count += 1;
         self.visit_symbol(&value);
+        Ok(())
+    }
+
+    fn visit_any_symbol(&mut self, _value: String) -> Self::T {
+        self.any_symbol_count += 1;
     }
 }
 

--- a/smt2parser/src/visitors.rs
+++ b/smt2parser/src/visitors.rs
@@ -19,7 +19,22 @@ pub trait ConstantVisitor {
 pub trait SymbolVisitor {
     type T;
 
-    fn visit_symbol(&mut self, value: String) -> Self::T;
+    fn visit_fresh_symbol(&mut self, value: String) -> Self::T;
+
+    // If it is not a valid bound symbol, return an error containing the value.
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, String> {
+        Ok(self.visit_fresh_symbol(value))
+    }
+
+    // If it is not a valid bound symbol, create a fresh one.
+    fn visit_any_symbol(&mut self, value: String) -> Self::T {
+        self.visit_bound_symbol(value)
+            .unwrap_or_else(|v| self.visit_fresh_symbol(v))
+    }
+
+    fn bind_symbol(&mut self, _symbol: &Self::T) {}
+
+    fn unbind_symbol(&mut self, _symbol: &Self::T) {}
 }
 
 pub trait KeywordVisitor {

--- a/smt2parser/src/visitors.rs
+++ b/smt2parser/src/visitors.rs
@@ -428,11 +428,11 @@ where
         use AttributeValue::*;
         match self {
             None => Ok(()),
-            Constant(c) => write!(f, " {}", c),
-            Symbol(s) => write!(f, " {}", s),
+            Constant(c) => write!(f, "{}", c),
+            Symbol(s) => write!(f, "{}", s),
             SExpr(values) => write!(
                 f,
-                " ({})",
+                "({})",
                 values
                     .iter()
                     .map(|i| format!("{}", i))

--- a/smt2patch/Cargo.toml
+++ b/smt2patch/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 [dependencies]
 rand = "0.8.0"
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.3.0" }
+smt2parser = { path = "../smt2parser", version = "0.4.0" }
 anyhow = "1.0.40"
 
 [[bin]]

--- a/smt2proxy/Cargo.toml
+++ b/smt2proxy/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 [dependencies]
 rand = "0.8.0"
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.3.0" }
+smt2parser = { path = "../smt2parser", version = "0.4.0" }
 
 [[bin]]
 name = "smt2proxy"

--- a/z3tracer/Cargo.toml
+++ b/z3tracer/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 
 [dependencies]
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.3.0" }
+smt2parser = { path = "../smt2parser", version = "0.4.0" }
 thiserror = "1.0.24"
 once_cell = "1.7.2"
 

--- a/z3tracer/src/main.rs
+++ b/z3tracer/src/main.rs
@@ -3,15 +3,12 @@
 
 #![forbid(unsafe_code)]
 
-use z3tracer::report::*;
-use z3tracer::{Model, ModelConfig};
+use z3tracer::{report::*, Model, ModelConfig};
 
 use multiset::HashMultiSet;
 use petgraph::graph::Graph;
 use plotters::prelude::*;
-use std::collections::*;
-use std::io::Write;
-use std::path::PathBuf;
+use std::{collections::*, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
 /// Test utility for the parsing and the analysis of Z3 log files.


### PR DESCRIPTION
Provide a working implementation of name resolution and name normalization for SMT2 files with the following caveats:
* The old syntax for testers `is-Foo` is not compatible with name resolution. One needs to replace `is-Foo` into `(_ is Foo)` first using the given rewriter `renaming::TesterModernizer` (see unit tests).
* Error handling is not fully satisfying yet: visitor APIs do not use `Result` yet and will `panic!` in case of unknown symbol. (However, this only affects people using the new name-resolution callbacks, not the parsing.)
* The LALR parser will attempt to call some of the new callbacks but proper name resolution requires to use `SyntaxBuilder` first, then visit the concrete syntax again. See the unit test of the utility type `renaming::SymbolNormalizer`.