### PR TITLE
[smt2parser] improve error handling by using Result types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "smt2parser"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "fst",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "pomelo",
  "serde",
  "structopt",
+ "thiserror",
 ]
 
 [[package]]
@@ -929,6 +930,7 @@ dependencies = [
  "rand",
  "smt2parser",
  "structopt",
+ "thiserror",
 ]
 
 [[package]]
@@ -1001,18 +1003,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/smt2parser/Cargo.toml
+++ b/smt2parser/Cargo.toml
@@ -22,6 +22,7 @@ structopt = "0.3.12"
 fst = "0.4.5"
 serde = { version = "1.0.125", features = ["derive"] }
 itertools = "0.10.0"
+thiserror = "1.0.25"
 
 [[bin]]
 name = "smt2bin"

--- a/smt2parser/Cargo.toml
+++ b/smt2parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smt2parser"
-version = "0.4.1"
+version = "0.5.0"
 description = "Generic parser library for the SMT-LIB-2 format"
 repository = "https://github.com/facebookincubator/smt2utils"
 documentation = "https://docs.rs/smt2parser"

--- a/smt2parser/src/lexer.rs
+++ b/smt2parser/src/lexer.rs
@@ -63,7 +63,7 @@ const KEYWORDS: &[(&str, Token)] = {
         ("echo", Echo),
         ("exit", Exit),
         ("get-assertions", GetAssertions),
-        ("get-assignments", GetAssignments),
+        ("get-assignment", GetAssignment),
         ("get-info", GetInfo),
         ("get-model", GetModel),
         ("get-option", GetOption),

--- a/smt2parser/src/main.rs
+++ b/smt2parser/src/main.rs
@@ -47,16 +47,12 @@ where
     T::Error: std::fmt::Display,
 {
     let file = std::io::BufReader::new(std::fs::File::open(&file_path)?);
-    let mut stream = CommandStream::new(file, state);
+    let mut stream = CommandStream::new(file, state, file_path.to_str().map(String::from));
     for result in &mut stream {
         match result {
             Ok(command) => f(command),
-            Err((position, error)) => {
-                eprintln!(
-                    "error: {}:\n --> {}",
-                    error,
-                    position.location_in_file(&file_path)
-                );
+            Err(error) => {
+                eprintln!("{}", error);
                 break;
             }
         }

--- a/smt2parser/src/main.rs
+++ b/smt2parser/src/main.rs
@@ -44,14 +44,19 @@ fn process_file<T, F>(state: T, file_path: PathBuf, f: F) -> std::io::Result<T>
 where
     T: smt2parser::visitors::Smt2Visitor,
     F: Fn(T::Command),
+    T::Error: std::fmt::Display,
 {
     let file = std::io::BufReader::new(std::fs::File::open(&file_path)?);
     let mut stream = CommandStream::new(file, state);
     for result in &mut stream {
         match result {
             Ok(command) => f(command),
-            Err(error) => {
-                eprintln!("error:\n --> {}", error.location_in_file(&file_path));
+            Err((position, error)) => {
+                eprintln!(
+                    "error: {}:\n --> {}",
+                    error,
+                    position.location_in_file(&file_path)
+                );
                 break;
             }
         }

--- a/smt2parser/src/parser.rs
+++ b/smt2parser/src/parser.rs
@@ -4,6 +4,7 @@
 #![allow(unused_braces)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::needless_lifetimes)]
 
 pub use internal::{Parser, Token};
 

--- a/smt2parser/src/parser.rs
+++ b/smt2parser/src/parser.rs
@@ -325,7 +325,7 @@ pomelo! {
     //   ( get-assertions )
     command ::= LeftParen GetAssertions RightParen { extra.visit_get_assertions()? }
     //   ( get-assignment )
-    command ::= LeftParen GetAssignments RightParen { extra.visit_get_assignment()? }
+    command ::= LeftParen GetAssignment RightParen { extra.visit_get_assignment()? }
     //   ( get-info ⟨info_flag⟩ )
     command ::= LeftParen GetInfo keyword(x) RightParen { extra.visit_get_info(x)? }
     //   ( get-model )

--- a/smt2parser/src/parser.rs
+++ b/smt2parser/src/parser.rs
@@ -15,7 +15,9 @@ pomelo! {
 
     %parser pub struct Parser<'a, T: visitors::Smt2Visitor> {};
     %extra_argument &'a mut T;
-
+    %error T::Error;
+    %syntax_error { Err(extra.syntax_error()) };
+    %parse_fail { extra.parsing_error("unrecoverable error".into()) };
     %token #[derive(Clone, Debug, PartialEq, Eq)] pub enum Token {};
 
     %type Keyword String;
@@ -86,10 +88,10 @@ pomelo! {
 
     %start_symbol command;
 
-    bound_symbol ::= Symbol(s) { extra.visit_bound_symbol(s).expect("failed to resolve symbol") }
-    fresh_symbol ::= Symbol(s) { extra.visit_fresh_symbol(s) }
-    any_symbol ::= Symbol(s) { extra.visit_any_symbol(s) }
-    keyword ::= Keyword(s) { extra.visit_keyword(s) }
+    bound_symbol ::= Symbol(s) { extra.visit_bound_symbol(s)? }
+    fresh_symbol ::= Symbol(s) { extra.visit_fresh_symbol(s)? }
+    any_symbol ::= Symbol(s) { extra.visit_any_symbol(s)? }
+    keyword ::= Keyword(s) { extra.visit_keyword(s)? }
 
     bound_symbols ::= bound_symbol(x) { vec![x] }
     bound_symbols ::= bound_symbols(mut xs) bound_symbol(x) { xs.push(x); xs }
@@ -108,10 +110,10 @@ pomelo! {
     attributes ::= attributes(mut xs) keyword(k) attribute_value(v) { xs.push((k, v)); xs }
 
     // s_expr ::= ⟨spec_constant⟩ | ⟨symbol⟩ | ⟨keyword⟩ | ( ⟨s_expr⟩∗ )
-    s_expr ::= constant(x) { extra.visit_constant_s_expr(x) }
-    s_expr ::= bound_symbol(x) { extra.visit_symbol_s_expr(x) }
-    s_expr ::= keyword(x) { extra.visit_keyword_s_expr(x) }
-    s_expr ::= LeftParen s_exprs?(xs) RightParen { extra.visit_application_s_expr(xs.unwrap_or_else(Vec::new)) }
+    s_expr ::= constant(x) { extra.visit_constant_s_expr(x)? }
+    s_expr ::= bound_symbol(x) { extra.visit_symbol_s_expr(x)? }
+    s_expr ::= keyword(x) { extra.visit_keyword_s_expr(x)? }
+    s_expr ::= LeftParen s_exprs?(xs) RightParen { extra.visit_application_s_expr(xs.unwrap_or_else(Vec::new))? }
 
     s_exprs ::= s_expr(x) { vec![x] }
     s_exprs ::= s_exprs(mut xs) s_expr(x) { xs.push(x); xs }
@@ -128,22 +130,22 @@ pomelo! {
     identifier ::= LeftParen Underscore bound_symbol(symbol) indices(indices) RightParen { visitors::Identifier::Indexed { symbol, indices } }
 
     // sort ::= ⟨identifier⟩ | ( ⟨identifier⟩ ⟨sort⟩+ )
-    sort ::= identifier(id) { extra.visit_simple_sort(id) }
-    sort ::= LeftParen identifier(id) sorts(sorts) RightParen { extra.visit_parameterized_sort(id, sorts) }
+    sort ::= identifier(id) { extra.visit_simple_sort(id)? }
+    sort ::= LeftParen identifier(id) sorts(sorts) RightParen { extra.visit_parameterized_sort(id, sorts)? }
 
     sorts ::= sort(x) { vec![x] }
     sorts ::= sorts(mut xs) sort(x) { xs.push(x); xs }
 
     // qual_identifier ::= ⟨identifier⟩ | ( as ⟨identifier⟩ ⟨sort⟩ )
-    qual_identifier ::= identifier(x) { extra.visit_simple_identifier(x) }
-    qual_identifier ::= LeftParen As identifier(id) sort(s) RightParen { extra.visit_sorted_identifier(id, s) }
+    qual_identifier ::= identifier(x) { extra.visit_simple_identifier(x)? }
+    qual_identifier ::= LeftParen As identifier(id) sort(s) RightParen { extra.visit_sorted_identifier(id, s)? }
 
     // constant ::= ⟨numeral⟩ | ⟨decimal⟩ | ⟨hexadecimal⟩ | ⟨binary⟩ | ⟨string⟩
-    constant ::= Numeral(x) { extra.visit_numeral_constant(x) }
-    constant ::= Decimal(x) { extra.visit_decimal_constant(x) }
-    constant ::= Hexadecimal(x) { extra.visit_hexadecimal_constant(x) }
-    constant ::= Binary(x) { extra.visit_binary_constant(x) }
-    constant ::= String(x) { extra.visit_string_constant(x) }
+    constant ::= Numeral(x) { extra.visit_numeral_constant(x)? }
+    constant ::= Decimal(x) { extra.visit_decimal_constant(x)? }
+    constant ::= Hexadecimal(x) { extra.visit_hexadecimal_constant(x)? }
+    constant ::= Binary(x) { extra.visit_binary_constant(x)? }
+    constant ::= String(x) { extra.visit_string_constant(x)? }
 
     // ⟨var_binding⟩ ::= ( ⟨symbol⟩ ⟨term⟩ )
     var_binding ::= LeftParen fresh_symbol(s) term(t) RightParen { (s, t) }
@@ -169,21 +171,21 @@ pomelo! {
 
     // terms ::= ...
     //   ⟨spec_constant⟩
-    term ::= constant(x) { extra.visit_constant(x) }
+    term ::= constant(x) { extra.visit_constant(x)? }
     //   ⟨qual_identifier⟩
-    term ::= qual_identifier(x) { extra.visit_qual_identifier(x) }
+    term ::= qual_identifier(x) { extra.visit_qual_identifier(x)? }
     //   ( let ( ⟨var_binding⟩+ ) ⟨term⟩ )
-    term ::= LeftParen Let LeftParen var_bindings(xs) RightParen term(t) RightParen { extra.visit_let(xs, t) }
+    term ::= LeftParen Let LeftParen var_bindings(xs) RightParen term(t) RightParen { extra.visit_let(xs, t)? }
     //   ( forall ( ⟨sorted_var⟩+ ) ⟨term⟩ )
-    term ::= LeftParen Forall LeftParen sorted_vars(xs) RightParen term(t) RightParen { extra.visit_forall(xs, t) }
+    term ::= LeftParen Forall LeftParen sorted_vars(xs) RightParen term(t) RightParen { extra.visit_forall(xs, t)? }
     //   ( exists ( ⟨sorted_var⟩+ ) ⟨term⟩ )
-    term ::= LeftParen Exists LeftParen sorted_vars(xs) RightParen term(t) RightParen { extra.visit_exists(xs, t) }
+    term ::= LeftParen Exists LeftParen sorted_vars(xs) RightParen term(t) RightParen { extra.visit_exists(xs, t)? }
     //   ( match ⟨term⟩ ( ⟨match_case⟩+ ) )
-    term ::= LeftParen Match term(t) LeftParen match_cases(xs) RightParen RightParen { extra.visit_match(t, xs) }
+    term ::= LeftParen Match term(t) LeftParen match_cases(xs) RightParen RightParen { extra.visit_match(t, xs)? }
     //   ( ! ⟨term⟩ ⟨attribute⟩+ )
-    term ::= LeftParen Exclam term(t) attributes(xs) RightParen { extra.visit_attributes(t, xs) }
+    term ::= LeftParen Exclam term(t) attributes(xs) RightParen { extra.visit_attributes(t, xs)? }
     //   ( ⟨qual_identifier ⟩ ⟨term⟩+ )
-    term ::= LeftParen qual_identifier(id) terms(xs) RightParen { extra.visit_application(id, xs) }
+    term ::= LeftParen qual_identifier(id) terms(xs) RightParen { extra.visit_application(id, xs)? }
 
     terms ::= term(x) { vec![x] }
     terms ::= terms(mut xs) term(x) { xs.push(x); xs }
@@ -192,7 +194,7 @@ pomelo! {
     prop_literal ::= bound_symbol(x) { (x, true) }
     prop_literal ::= LeftParen Symbol(s) bound_symbol(x) RightParen {
         if s != "not" {
-            return Err(());
+            return Err(extra.parsing_error(format!("invalid prop_literal: found {} instead of `not`", s)));
         }
         (x, false)
     }
@@ -249,23 +251,23 @@ pomelo! {
 
     // command ::= ...
     //   ( assert ⟨term⟩ )
-    command ::= LeftParen Assert term(t) RightParen { extra.visit_assert(t) }
+    command ::= LeftParen Assert term(t) RightParen { extra.visit_assert(t)? }
     //   ( check-sat )
-    command ::= LeftParen CheckSat RightParen { extra.visit_check_sat() }
+    command ::= LeftParen CheckSat RightParen { extra.visit_check_sat()? }
     //   ( check-sat-assuming ( ⟨prop_literal⟩∗ ) )
     command ::= LeftParen CheckSatAssuming LeftParen prop_literals?(xs) RightParen RightParen
     {
-        extra.visit_check_sat_assuming(xs.unwrap_or_else(Vec::new))
+        extra.visit_check_sat_assuming(xs.unwrap_or_else(Vec::new))?
     }
     //   ( declare-const ⟨symbol⟩ ⟨sort⟩ )
     command ::= LeftParen DeclareConst fresh_symbol(x) sort(s) RightParen
     {
-        extra.visit_declare_const(x, s)
+        extra.visit_declare_const(x, s)?
     }
     //   ( declare-datatype ⟨symbol⟩ ⟨datatype_dec⟩)
     command ::= LeftParen DeclareDatatype fresh_symbol(s) datatype_dec(d) RightParen
     {
-        extra.visit_declare_datatype(s, d)
+        extra.visit_declare_datatype(s, d)?
     }
     //   ( declare-datatypes ( ⟨sort_dec⟩n+1 ) ( ⟨datatype_dec⟩n+1 ) )
     command ::= LeftParen DeclareDatatypes LeftParen sort_decs(sorts) RightParen LeftParen datatype_decs(datatypes) RightParen RightParen
@@ -276,82 +278,82 @@ pomelo! {
                 .zip(datatypes.into_iter())
                 .map(|((sort, arity), datatype)| (sort, arity, datatype))
                 .collect::<Vec<_>>();
-            extra.visit_declare_datatypes(results)
+            extra.visit_declare_datatypes(results)?
         } else {
-            return Err(());
+            return Err(extra.parsing_error(format!("wrong number of types in `declare-datatypes`: {} instead of {}", datatypes.len(), sorts.len())));
         }
     }
     //   ( declare-fun ⟨symbol⟩ ( ⟨sort⟩∗ ) ⟨sort⟩ )
     command ::= LeftParen DeclareFun fresh_symbol(x) LeftParen sorts?(xs) RightParen sort(r) RightParen
     {
-        extra.visit_declare_fun(x, xs.unwrap_or_else(Vec::new), r)
+        extra.visit_declare_fun(x, xs.unwrap_or_else(Vec::new), r)?
     }
     //   ( declare-sort ⟨symbol⟩ ⟨numeral⟩ )
     command ::= LeftParen DeclareSort fresh_symbol(x) Numeral(num) RightParen
     {
-        extra.visit_declare_sort(x, num)
+        extra.visit_declare_sort(x, num)?
     }
     //   ( define-fun ⟨function_dec⟩ ⟨term⟩ )
     command ::= LeftParen DefineFun function_dec(d) term(x) RightParen
     {
-        extra.visit_define_fun(d, x)
+        extra.visit_define_fun(d, x)?
     }
     //   ( define-fun-rec ⟨function_dec⟩ ⟨term⟩ )
     command ::= LeftParen DefineFunRec function_dec(d) term(x) RightParen
     {
-        extra.visit_define_fun_rec(d, x)
+        extra.visit_define_fun_rec(d, x)?
     }
     //   ( define-funs-rec ( ( ⟨function_dec⟩ )n+1 ) ( ⟨term⟩n+1 ) )
     command ::= LeftParen DefineFunsRec LeftParen function_decs(sigs) RightParen LeftParen terms(xs) RightParen RightParen
     {
         if sigs.len() == xs.len() {
             let defs = sigs.into_iter().zip(xs.into_iter()).collect::<Vec<_>>();
-            extra.visit_define_funs_rec(defs)
+            extra.visit_define_funs_rec(defs)?
         } else {
-            return Err(());
+            return Err(extra.parsing_error(format!("wrong number of function bodies in `define-funs-rec`: {} instead of {}", xs.len(), sigs.len())));
         }
     }
     //   ( define-sort ⟨symbol⟩ ( ⟨symbol⟩∗ ) ⟨sort⟩ )
     command ::= LeftParen DefineSort fresh_symbol(x) LeftParen bound_symbols?(xs) RightParen sort(r) RightParen
     {
-        extra.visit_define_sort(x, xs.unwrap_or_else(Vec::new), r)
+        extra.visit_define_sort(x, xs.unwrap_or_else(Vec::new), r)?
     }
     //   ( echo ⟨string⟩ )
-    command ::= LeftParen Echo String(x) RightParen { extra.visit_echo(x) }
+    command ::= LeftParen Echo String(x) RightParen { extra.visit_echo(x)? }
     //   ( exit )
-    command ::= LeftParen Exit RightParen { extra.visit_exit() }
+    command ::= LeftParen Exit RightParen { extra.visit_exit()? }
     //   ( get-assertions )
-    command ::= LeftParen GetAssertions RightParen { extra.visit_get_assertions() }
+    command ::= LeftParen GetAssertions RightParen { extra.visit_get_assertions()? }
     //   ( get-assignment )
-    command ::= LeftParen GetAssignments RightParen { extra.visit_get_assignment() }
+    command ::= LeftParen GetAssignments RightParen { extra.visit_get_assignment()? }
     //   ( get-info ⟨info_flag⟩ )
-    command ::= LeftParen GetInfo keyword(x) RightParen { extra.visit_get_info(x) }
+    command ::= LeftParen GetInfo keyword(x) RightParen { extra.visit_get_info(x)? }
     //   ( get-model )
-    command ::= LeftParen GetModel RightParen { extra.visit_get_model() }
+    command ::= LeftParen GetModel RightParen { extra.visit_get_model()? }
     //   ( get-option ⟨keyword⟩ )
-    command ::= LeftParen GetOption keyword(x) RightParen { extra.visit_get_option(x) }
+    command ::= LeftParen GetOption keyword(x) RightParen { extra.visit_get_option(x)? }
     //   ( get-proof )
-    command ::= LeftParen GetProof RightParen { extra.visit_get_proof() }
+    command ::= LeftParen GetProof RightParen { extra.visit_get_proof()? }
     //   ( get-unsat-assumptions )
-    command ::= LeftParen GetUnsatAssumptions RightParen { extra.visit_get_unsat_assumptions() }
+    command ::= LeftParen GetUnsatAssumptions RightParen { extra.visit_get_unsat_assumptions()? }
     //   ( get-unsat-core )
-    command ::= LeftParen GetUnsatCore RightParen { extra.visit_get_unsat_core() }
+    command ::= LeftParen GetUnsatCore RightParen { extra.visit_get_unsat_core()? }
     //   ( get-value )
-    command ::= LeftParen GetValue terms(xs) RightParen { extra.visit_get_value(xs) }
+    command ::= LeftParen GetValue terms(xs) RightParen { extra.visit_get_value(xs)? }
     //   ( pop ⟨numeral⟩ )
-    command ::= LeftParen Pop Numeral(x) RightParen { extra.visit_pop(x) }
+    command ::= LeftParen Pop Numeral(x) RightParen { extra.visit_pop(x)? }
     //   ( push ⟨numeral⟩ )
-    command ::= LeftParen Push Numeral(x) RightParen { extra.visit_push(x) }
+    command ::= LeftParen Push Numeral(x) RightParen { extra.visit_push(x)? }
     //   ( reset )
-    command ::= LeftParen Reset RightParen { extra.visit_reset() }
+    command ::= LeftParen Reset RightParen { extra.visit_reset()? }
     //   ( reset-assertions )
-    command ::= LeftParen ResetAssertions RightParen { extra.visit_reset_assertions() }
+    command ::= LeftParen ResetAssertions RightParen { extra.visit_reset_assertions()? }
     //   ( set-info ⟨attribute⟩ )
-    command ::= LeftParen SetInfo keyword(k) attribute_value(v) RightParen { extra.visit_set_info(k, v) }
+    command ::= LeftParen SetInfo keyword(k) attribute_value(v) RightParen { extra.visit_set_info(k, v)? }
     //   ( set-logic ⟨symbol⟩ )
-    command ::= LeftParen SetLogic bound_symbol(x) RightParen { extra.visit_set_logic(x) }
+    command ::= LeftParen SetLogic bound_symbol(x) RightParen { extra.visit_set_logic(x)? }
     //   ( set-option ⟨attribute⟩ )
-    command ::= LeftParen SetOption keyword(k) attribute_value(v) RightParen { extra.visit_set_option(k, v) }
+    command ::= LeftParen SetOption keyword(k) attribute_value(v) RightParen { extra.visit_set_option(k, v)? }
 }
 
 #[cfg(test)]
@@ -359,7 +361,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::{concrete::*, lexer::Lexer};
 
-    pub(crate) fn parse_tokens<I: IntoIterator<Item = Token>>(tokens: I) -> Result<Command, ()> {
+    pub(crate) fn parse_tokens<I: IntoIterator<Item = Token>>(tokens: I) -> Result<Command, Error> {
         let mut builder = SyntaxBuilder;
         let mut p = Parser::new(&mut builder);
         for token in tokens.into_iter() {
@@ -504,7 +506,10 @@ pub(crate) mod tests {
         // Test syntax visiting while we're at it.
         assert_eq!(
             value,
-            value.clone().accept(&mut crate::concrete::SyntaxBuilder)
+            value
+                .clone()
+                .accept(&mut crate::concrete::SyntaxBuilder)
+                .unwrap()
         );
     }
 }

--- a/smt2parser/src/renaming.rs
+++ b/smt2parser/src/renaming.rs
@@ -117,7 +117,7 @@ where
                 self.global_symbols.insert(value.clone());
                 Symbol(value)
             });
-        Ok(self.process_symbol(value)?)
+        self.process_symbol(value)
     }
 
     fn visit_fresh_symbol(&mut self, value: String) -> Result<Symbol, Error> {
@@ -169,7 +169,7 @@ fn test_testers() {
     // Visit with the TesterModernizer this time.
     let mut builder = TesterModernizer::<SyntaxBuilder>::default();
     assert!(matches!(
-        value.clone().accept(&mut builder).unwrap(),
+        value.accept(&mut builder).unwrap(),
         Command::Assert {
             term: Term::Application {
                 qual_identifier: QualIdentifier::Simple {
@@ -211,7 +211,7 @@ fn test_declare_datatypes_renaming() {
     assert_eq!(value, value.clone().accept(&mut builder).unwrap());
 
     let mut builder = SymbolNormalizer::<SyntaxBuilder>::default();
-    assert_eq!(value2, value.clone().accept(&mut builder).unwrap());
+    assert_eq!(value2, value.accept(&mut builder).unwrap());
 }
 
 #[test]

--- a/smt2parser/src/renaming.rs
+++ b/smt2parser/src/renaming.rs
@@ -150,7 +150,7 @@ where
 
 #[test]
 fn test_testers() {
-    use crate::{lexer::Lexer, parser::tests::parse_tokens};
+    use crate::{concrete, lexer::Lexer, parser::tests::parse_tokens};
 
     let value = parse_tokens(Lexer::new(&b"(assert (is-Foo 3))"[..])).unwrap();
     assert!(matches!(
@@ -164,13 +164,8 @@ fn test_testers() {
             }
         }
     ));
-    assert_eq!(
-        value,
-        value
-            .clone()
-            .accept(&mut crate::concrete::SyntaxBuilder)
-            .unwrap()
-    );
+    let mut builder = concrete::SyntaxBuilder::default();
+    assert_eq!(value, value.clone().accept(&mut builder).unwrap());
     // Visit with the TesterModernizer this time.
     let mut builder = TesterModernizer::<SyntaxBuilder>::default();
     assert!(matches!(
@@ -212,14 +207,8 @@ fn test_declare_datatypes_renaming() {
     ))
     .unwrap();
     assert!(matches!(value2, Command::DeclareDatatypes { .. }));
-
-    assert_eq!(
-        value,
-        value
-            .clone()
-            .accept(&mut crate::concrete::SyntaxBuilder)
-            .unwrap()
-    );
+    let mut builder = SyntaxBuilder::default();
+    assert_eq!(value, value.clone().accept(&mut builder).unwrap());
 
     let mut builder = SymbolNormalizer::<SyntaxBuilder>::default();
     assert_eq!(value2, value.clone().accept(&mut builder).unwrap());

--- a/smt2parser/src/rewriter.rs
+++ b/smt2parser/src/rewriter.rs
@@ -17,6 +17,7 @@ use crate::{
 /// Helper trait to create variants of an existing Smt2Visitor.
 pub trait Rewriter {
     type V: Smt2Visitor;
+    type Error: std::convert::From<<Self::V as Smt2Visitor>::Error>;
 
     /// Delegate visitor
     fn visitor(&mut self) -> &mut Self::V;
@@ -25,74 +26,86 @@ pub trait Rewriter {
     fn process_constant(
         &mut self,
         value: <Self::V as Smt2Visitor>::Constant,
-    ) -> <Self::V as Smt2Visitor>::Constant {
-        value
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        Ok(value)
     }
     fn process_symbol(
         &mut self,
         value: <Self::V as Smt2Visitor>::Symbol,
-    ) -> <Self::V as Smt2Visitor>::Symbol {
-        value
+    ) -> Result<<Self::V as Smt2Visitor>::Symbol, Self::Error> {
+        Ok(value)
     }
     fn process_keyword(
         &mut self,
         value: <Self::V as Smt2Visitor>::Keyword,
-    ) -> <Self::V as Smt2Visitor>::Keyword {
-        value
+    ) -> Result<<Self::V as Smt2Visitor>::Keyword, Self::Error> {
+        Ok(value)
     }
     fn process_s_expr(
         &mut self,
         value: <Self::V as Smt2Visitor>::SExpr,
-    ) -> <Self::V as Smt2Visitor>::SExpr {
-        value
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        Ok(value)
     }
     fn process_sort(
         &mut self,
         value: <Self::V as Smt2Visitor>::Sort,
-    ) -> <Self::V as Smt2Visitor>::Sort {
-        value
+    ) -> Result<<Self::V as Smt2Visitor>::Sort, Self::Error> {
+        Ok(value)
     }
     fn process_qual_identifier(
         &mut self,
         value: <Self::V as Smt2Visitor>::QualIdentifier,
-    ) -> <Self::V as Smt2Visitor>::QualIdentifier {
-        value
+    ) -> Result<<Self::V as Smt2Visitor>::QualIdentifier, Self::Error> {
+        Ok(value)
     }
     fn process_term(
         &mut self,
         value: <Self::V as Smt2Visitor>::Term,
-    ) -> <Self::V as Smt2Visitor>::Term {
-        value
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        Ok(value)
     }
     fn process_command(
         &mut self,
         value: <Self::V as Smt2Visitor>::Command,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        value
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        Ok(value)
     }
 
     // ConstantVisitor
-    fn visit_numeral_constant(&mut self, value: Numeral) -> <Self::V as Smt2Visitor>::Constant {
-        let value = self.visitor().visit_numeral_constant(value);
+    fn visit_numeral_constant(
+        &mut self,
+        value: Numeral,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_numeral_constant(value)?;
         self.process_constant(value)
     }
-    fn visit_decimal_constant(&mut self, value: Decimal) -> <Self::V as Smt2Visitor>::Constant {
-        let value = self.visitor().visit_decimal_constant(value);
+    fn visit_decimal_constant(
+        &mut self,
+        value: Decimal,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_decimal_constant(value)?;
         self.process_constant(value)
     }
     fn visit_hexadecimal_constant(
         &mut self,
         value: Hexadecimal,
-    ) -> <Self::V as Smt2Visitor>::Constant {
-        let value = self.visitor().visit_hexadecimal_constant(value);
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_hexadecimal_constant(value)?;
         self.process_constant(value)
     }
-    fn visit_binary_constant(&mut self, value: Binary) -> <Self::V as Smt2Visitor>::Constant {
-        let value = self.visitor().visit_binary_constant(value);
+    fn visit_binary_constant(
+        &mut self,
+        value: Binary,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_binary_constant(value)?;
         self.process_constant(value)
     }
-    fn visit_string_constant(&mut self, value: String) -> <Self::V as Smt2Visitor>::Constant {
-        let value = self.visitor().visit_string_constant(value);
+    fn visit_string_constant(
+        &mut self,
+        value: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_string_constant(value)?;
         self.process_constant(value)
     }
 
@@ -100,18 +113,24 @@ pub trait Rewriter {
     fn visit_bound_symbol(
         &mut self,
         value: String,
-    ) -> Result<<Self::V as Smt2Visitor>::Symbol, String> {
-        let value = self.visitor().visit_bound_symbol(value);
-        value.map(|s| self.process_symbol(s))
-    }
-
-    fn visit_fresh_symbol(&mut self, value: String) -> <Self::V as Smt2Visitor>::Symbol {
-        let value = self.visitor().visit_fresh_symbol(value);
+    ) -> Result<<Self::V as Smt2Visitor>::Symbol, Self::Error> {
+        let value = self.visitor().visit_bound_symbol(value)?;
         self.process_symbol(value)
     }
 
-    fn visit_any_symbol(&mut self, value: String) -> <Self::V as Smt2Visitor>::Symbol {
-        let value = self.visitor().visit_any_symbol(value);
+    fn visit_fresh_symbol(
+        &mut self,
+        value: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Symbol, Self::Error> {
+        let value = self.visitor().visit_fresh_symbol(value)?;
+        self.process_symbol(value)
+    }
+
+    fn visit_any_symbol(
+        &mut self,
+        value: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Symbol, Self::Error> {
+        let value = self.visitor().visit_any_symbol(value)?;
         self.process_symbol(value)
     }
 
@@ -124,8 +143,11 @@ pub trait Rewriter {
     }
 
     // KeywordVisitor
-    fn visit_keyword(&mut self, value: String) -> <Self::V as Smt2Visitor>::Keyword {
-        let value = self.visitor().visit_keyword(value);
+    fn visit_keyword(
+        &mut self,
+        value: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Keyword, Self::Error> {
+        let value = self.visitor().visit_keyword(value)?;
         self.process_keyword(value)
     }
 
@@ -133,29 +155,29 @@ pub trait Rewriter {
     fn visit_constant_s_expr(
         &mut self,
         value: <Self::V as Smt2Visitor>::Constant,
-    ) -> <Self::V as Smt2Visitor>::SExpr {
-        let value = self.visitor().visit_constant_s_expr(value);
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        let value = self.visitor().visit_constant_s_expr(value)?;
         self.process_s_expr(value)
     }
     fn visit_symbol_s_expr(
         &mut self,
         value: <Self::V as Smt2Visitor>::Symbol,
-    ) -> <Self::V as Smt2Visitor>::SExpr {
-        let value = self.visitor().visit_symbol_s_expr(value);
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        let value = self.visitor().visit_symbol_s_expr(value)?;
         self.process_s_expr(value)
     }
     fn visit_keyword_s_expr(
         &mut self,
         value: <Self::V as Smt2Visitor>::Keyword,
-    ) -> <Self::V as Smt2Visitor>::SExpr {
-        let value = self.visitor().visit_keyword_s_expr(value);
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        let value = self.visitor().visit_keyword_s_expr(value)?;
         self.process_s_expr(value)
     }
     fn visit_application_s_expr(
         &mut self,
         values: Vec<<Self::V as Smt2Visitor>::SExpr>,
-    ) -> <Self::V as Smt2Visitor>::SExpr {
-        let value = self.visitor().visit_application_s_expr(values);
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        let value = self.visitor().visit_application_s_expr(values)?;
         self.process_s_expr(value)
     }
 
@@ -163,18 +185,18 @@ pub trait Rewriter {
     fn visit_simple_sort(
         &mut self,
         identifier: Identifier<<Self::V as Smt2Visitor>::Symbol>,
-    ) -> <Self::V as Smt2Visitor>::Sort {
-        let value = self.visitor().visit_simple_sort(identifier);
+    ) -> Result<<Self::V as Smt2Visitor>::Sort, Self::Error> {
+        let value = self.visitor().visit_simple_sort(identifier)?;
         self.process_sort(value)
     }
     fn visit_parameterized_sort(
         &mut self,
         identifier: Identifier<<Self::V as Smt2Visitor>::Symbol>,
         parameters: Vec<<Self::V as Smt2Visitor>::Sort>,
-    ) -> <Self::V as Smt2Visitor>::Sort {
+    ) -> Result<<Self::V as Smt2Visitor>::Sort, Self::Error> {
         let value = self
             .visitor()
-            .visit_parameterized_sort(identifier, parameters);
+            .visit_parameterized_sort(identifier, parameters)?;
         self.process_sort(value)
     }
 
@@ -182,16 +204,16 @@ pub trait Rewriter {
     fn visit_simple_identifier(
         &mut self,
         identifier: Identifier<<Self::V as Smt2Visitor>::Symbol>,
-    ) -> <Self::V as Smt2Visitor>::QualIdentifier {
-        let value = self.visitor().visit_simple_identifier(identifier);
+    ) -> Result<<Self::V as Smt2Visitor>::QualIdentifier, Self::Error> {
+        let value = self.visitor().visit_simple_identifier(identifier)?;
         self.process_qual_identifier(value)
     }
     fn visit_sorted_identifier(
         &mut self,
         identifier: Identifier<<Self::V as Smt2Visitor>::Symbol>,
         sort: <Self::V as Smt2Visitor>::Sort,
-    ) -> <Self::V as Smt2Visitor>::QualIdentifier {
-        let value = self.visitor().visit_sorted_identifier(identifier, sort);
+    ) -> Result<<Self::V as Smt2Visitor>::QualIdentifier, Self::Error> {
+        let value = self.visitor().visit_sorted_identifier(identifier, sort)?;
         self.process_qual_identifier(value)
     }
 
@@ -199,23 +221,25 @@ pub trait Rewriter {
     fn visit_constant(
         &mut self,
         constant: <Self::V as Smt2Visitor>::Constant,
-    ) -> <Self::V as Smt2Visitor>::Term {
-        let value = self.visitor().visit_constant(constant);
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_constant(constant)?;
         self.process_term(value)
     }
     fn visit_qual_identifier(
         &mut self,
         qual_identifier: <Self::V as Smt2Visitor>::QualIdentifier,
-    ) -> <Self::V as Smt2Visitor>::Term {
-        let value = self.visitor().visit_qual_identifier(qual_identifier);
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_qual_identifier(qual_identifier)?;
         self.process_term(value)
     }
     fn visit_application(
         &mut self,
         qual_identifier: <Self::V as Smt2Visitor>::QualIdentifier,
         arguments: Vec<<Self::V as Smt2Visitor>::Term>,
-    ) -> <Self::V as Smt2Visitor>::Term {
-        let value = self.visitor().visit_application(qual_identifier, arguments);
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self
+            .visitor()
+            .visit_application(qual_identifier, arguments)?;
         self.process_term(value)
     }
     fn visit_let(
@@ -225,8 +249,8 @@ pub trait Rewriter {
             <Self::V as Smt2Visitor>::Term,
         )>,
         term: <Self::V as Smt2Visitor>::Term,
-    ) -> <Self::V as Smt2Visitor>::Term {
-        let value = self.visitor().visit_let(var_bindings, term);
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_let(var_bindings, term)?;
         self.process_term(value)
     }
     fn visit_forall(
@@ -236,8 +260,8 @@ pub trait Rewriter {
             <Self::V as Smt2Visitor>::Sort,
         )>,
         term: <Self::V as Smt2Visitor>::Term,
-    ) -> <Self::V as Smt2Visitor>::Term {
-        let value = self.visitor().visit_forall(vars, term);
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_forall(vars, term)?;
         self.process_term(value)
     }
     fn visit_exists(
@@ -247,8 +271,8 @@ pub trait Rewriter {
             <Self::V as Smt2Visitor>::Sort,
         )>,
         term: <Self::V as Smt2Visitor>::Term,
-    ) -> <Self::V as Smt2Visitor>::Term {
-        let value = self.visitor().visit_exists(vars, term);
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_exists(vars, term)?;
         self.process_term(value)
     }
     fn visit_match(
@@ -258,8 +282,8 @@ pub trait Rewriter {
             Vec<<Self::V as Smt2Visitor>::Symbol>,
             <Self::V as Smt2Visitor>::Term,
         )>,
-    ) -> <Self::V as Smt2Visitor>::Term {
-        let value = self.visitor().visit_match(term, cases);
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_match(term, cases)?;
         self.process_term(value)
     }
     fn visit_attributes(
@@ -273,8 +297,8 @@ pub trait Rewriter {
                 <Self::V as Smt2Visitor>::SExpr,
             >,
         )>,
-    ) -> <Self::V as Smt2Visitor>::Term {
-        let value = self.visitor().visit_attributes(term, attributes);
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_attributes(term, attributes)?;
         self.process_term(value)
     }
 
@@ -282,35 +306,35 @@ pub trait Rewriter {
     fn visit_assert(
         &mut self,
         term: <Self::V as Smt2Visitor>::Term,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_assert(term);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_assert(term)?;
         self.process_command(value)
     }
-    fn visit_check_sat(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_check_sat();
+    fn visit_check_sat(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_check_sat()?;
         self.process_command(value)
     }
     fn visit_check_sat_assuming(
         &mut self,
         literals: Vec<(<Self::V as Smt2Visitor>::Symbol, bool)>,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_check_sat_assuming(literals);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_check_sat_assuming(literals)?;
         self.process_command(value)
     }
     fn visit_declare_const(
         &mut self,
         symbol: <Self::V as Smt2Visitor>::Symbol,
         sort: <Self::V as Smt2Visitor>::Sort,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_declare_const(symbol, sort);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_const(symbol, sort)?;
         self.process_command(value)
     }
     fn visit_declare_datatype(
         &mut self,
         symbol: <Self::V as Smt2Visitor>::Symbol,
         datatype: DatatypeDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_declare_datatype(symbol, datatype);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_datatype(symbol, datatype)?;
         self.process_command(value)
     }
     fn visit_declare_datatypes(
@@ -320,8 +344,8 @@ pub trait Rewriter {
             Numeral,
             DatatypeDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
         )>,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_declare_datatypes(datatypes);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_datatypes(datatypes)?;
         self.process_command(value)
     }
     fn visit_declare_fun(
@@ -329,32 +353,32 @@ pub trait Rewriter {
         symbol: <Self::V as Smt2Visitor>::Symbol,
         parameters: Vec<<Self::V as Smt2Visitor>::Sort>,
         sort: <Self::V as Smt2Visitor>::Sort,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_declare_fun(symbol, parameters, sort);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_fun(symbol, parameters, sort)?;
         self.process_command(value)
     }
     fn visit_declare_sort(
         &mut self,
         symbol: <Self::V as Smt2Visitor>::Symbol,
         arity: Numeral,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_declare_sort(symbol, arity);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_sort(symbol, arity)?;
         self.process_command(value)
     }
     fn visit_define_fun(
         &mut self,
         sig: FunctionDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
         term: <Self::V as Smt2Visitor>::Term,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_define_fun(sig, term);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_define_fun(sig, term)?;
         self.process_command(value)
     }
     fn visit_define_fun_rec(
         &mut self,
         sig: FunctionDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
         term: <Self::V as Smt2Visitor>::Term,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_define_fun_rec(sig, term);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_define_fun_rec(sig, term)?;
         self.process_command(value)
     }
     fn visit_define_funs_rec(
@@ -363,8 +387,8 @@ pub trait Rewriter {
             FunctionDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
             <Self::V as Smt2Visitor>::Term,
         )>,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_define_funs_rec(funs);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_define_funs_rec(funs)?;
         self.process_command(value)
     }
     fn visit_define_sort(
@@ -372,77 +396,88 @@ pub trait Rewriter {
         symbol: <Self::V as Smt2Visitor>::Symbol,
         parameters: Vec<<Self::V as Smt2Visitor>::Symbol>,
         sort: <Self::V as Smt2Visitor>::Sort,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_define_sort(symbol, parameters, sort);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_define_sort(symbol, parameters, sort)?;
         self.process_command(value)
     }
-    fn visit_echo(&mut self, message: String) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_echo(message);
+    fn visit_echo(
+        &mut self,
+        message: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_echo(message)?;
         self.process_command(value)
     }
-    fn visit_exit(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_exit();
+    fn visit_exit(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_exit()?;
         self.process_command(value)
     }
-    fn visit_get_assertions(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_get_assertions();
+    fn visit_get_assertions(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_assertions()?;
         self.process_command(value)
     }
-    fn visit_get_assignment(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_get_assignment();
+    fn visit_get_assignment(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_assignment()?;
         self.process_command(value)
     }
     fn visit_get_info(
         &mut self,
         flag: <Self::V as Smt2Visitor>::Keyword,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_get_info(flag);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_info(flag)?;
         self.process_command(value)
     }
-    fn visit_get_model(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_get_model();
+    fn visit_get_model(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_model()?;
         self.process_command(value)
     }
     fn visit_get_option(
         &mut self,
         keyword: <Self::V as Smt2Visitor>::Keyword,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_get_option(keyword);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_option(keyword)?;
         self.process_command(value)
     }
-    fn visit_get_proof(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_get_proof();
+    fn visit_get_proof(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_proof()?;
         self.process_command(value)
     }
-    fn visit_get_unsat_assumptions(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_get_unsat_assumptions();
+    fn visit_get_unsat_assumptions(
+        &mut self,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_unsat_assumptions()?;
         self.process_command(value)
     }
-    fn visit_get_unsat_core(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_get_unsat_core();
+    fn visit_get_unsat_core(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_unsat_core()?;
         self.process_command(value)
     }
     fn visit_get_value(
         &mut self,
         terms: Vec<<Self::V as Smt2Visitor>::Term>,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_get_value(terms);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_value(terms)?;
         self.process_command(value)
     }
-    fn visit_pop(&mut self, level: Numeral) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_pop(level);
+    fn visit_pop(
+        &mut self,
+        level: Numeral,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_pop(level)?;
         self.process_command(value)
     }
-    fn visit_push(&mut self, level: Numeral) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_push(level);
+    fn visit_push(
+        &mut self,
+        level: Numeral,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_push(level)?;
         self.process_command(value)
     }
-    fn visit_reset(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_reset();
+    fn visit_reset(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_reset()?;
         self.process_command(value)
     }
-    fn visit_reset_assertions(&mut self) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_reset_assertions();
+    fn visit_reset_assertions(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_reset_assertions()?;
         self.process_command(value)
     }
     fn visit_set_info(
@@ -453,15 +488,15 @@ pub trait Rewriter {
             <Self::V as Smt2Visitor>::Symbol,
             <Self::V as Smt2Visitor>::SExpr,
         >,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_set_info(keyword, value);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_set_info(keyword, value)?;
         self.process_command(value)
     }
     fn visit_set_logic(
         &mut self,
         symbol: <Self::V as Smt2Visitor>::Symbol,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_set_logic(symbol);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_set_logic(symbol)?;
         self.process_command(value)
     }
     fn visit_set_option(
@@ -472,8 +507,8 @@ pub trait Rewriter {
             <Self::V as Smt2Visitor>::Symbol,
             <Self::V as Smt2Visitor>::SExpr,
         >,
-    ) -> <Self::V as Smt2Visitor>::Command {
-        let value = self.visitor().visit_set_option(keyword, value);
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_set_option(keyword, value)?;
         self.process_command(value)
     }
 }
@@ -484,20 +519,21 @@ where
     V: Smt2Visitor,
 {
     type T = V::Constant;
+    type E = R::Error;
 
-    fn visit_numeral_constant(&mut self, value: Numeral) -> Self::T {
+    fn visit_numeral_constant(&mut self, value: Numeral) -> Result<Self::T, Self::E> {
         self.visit_numeral_constant(value)
     }
-    fn visit_decimal_constant(&mut self, value: Decimal) -> Self::T {
+    fn visit_decimal_constant(&mut self, value: Decimal) -> Result<Self::T, Self::E> {
         self.visit_decimal_constant(value)
     }
-    fn visit_hexadecimal_constant(&mut self, value: Hexadecimal) -> Self::T {
+    fn visit_hexadecimal_constant(&mut self, value: Hexadecimal) -> Result<Self::T, Self::E> {
         self.visit_hexadecimal_constant(value)
     }
-    fn visit_binary_constant(&mut self, value: Binary) -> Self::T {
+    fn visit_binary_constant(&mut self, value: Binary) -> Result<Self::T, Self::E> {
         self.visit_binary_constant(value)
     }
-    fn visit_string_constant(&mut self, value: String) -> Self::T {
+    fn visit_string_constant(&mut self, value: String) -> Result<Self::T, Self::E> {
         self.visit_string_constant(value)
     }
 }
@@ -508,16 +544,17 @@ where
     V: Smt2Visitor,
 {
     type T = V::Symbol;
+    type E = R::Error;
 
-    fn visit_fresh_symbol(&mut self, value: String) -> Self::T {
+    fn visit_fresh_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
         self.visit_fresh_symbol(value)
     }
 
-    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, String> {
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
         self.visit_bound_symbol(value)
     }
 
-    fn visit_any_symbol(&mut self, value: String) -> Self::T {
+    fn visit_any_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
         self.visit_any_symbol(value)
     }
 
@@ -536,8 +573,9 @@ where
     V: Smt2Visitor,
 {
     type T = V::Keyword;
+    type E = R::Error;
 
-    fn visit_keyword(&mut self, value: String) -> Self::T {
+    fn visit_keyword(&mut self, value: String) -> Result<Self::T, Self::E> {
         self.visit_keyword(value)
     }
 }
@@ -548,20 +586,21 @@ where
     V: Smt2Visitor,
 {
     type T = V::SExpr;
+    type E = R::Error;
 
-    fn visit_constant_s_expr(&mut self, value: V::Constant) -> Self::T {
+    fn visit_constant_s_expr(&mut self, value: V::Constant) -> Result<Self::T, Self::E> {
         self.visit_constant_s_expr(value)
     }
 
-    fn visit_symbol_s_expr(&mut self, value: V::Symbol) -> Self::T {
+    fn visit_symbol_s_expr(&mut self, value: V::Symbol) -> Result<Self::T, Self::E> {
         self.visit_symbol_s_expr(value)
     }
 
-    fn visit_keyword_s_expr(&mut self, value: V::Keyword) -> Self::T {
+    fn visit_keyword_s_expr(&mut self, value: V::Keyword) -> Result<Self::T, Self::E> {
         self.visit_keyword_s_expr(value)
     }
 
-    fn visit_application_s_expr(&mut self, values: Vec<Self::T>) -> Self::T {
+    fn visit_application_s_expr(&mut self, values: Vec<Self::T>) -> Result<Self::T, Self::E> {
         self.visit_application_s_expr(values)
     }
 }
@@ -572,8 +611,9 @@ where
     V: Smt2Visitor,
 {
     type T = V::Sort;
+    type E = R::Error;
 
-    fn visit_simple_sort(&mut self, identifier: Identifier<V::Symbol>) -> Self::T {
+    fn visit_simple_sort(&mut self, identifier: Identifier<V::Symbol>) -> Result<Self::T, Self::E> {
         self.visit_simple_sort(identifier)
     }
 
@@ -581,7 +621,7 @@ where
         &mut self,
         identifier: Identifier<V::Symbol>,
         parameters: Vec<Self::T>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_parameterized_sort(identifier, parameters)
     }
 }
@@ -592,8 +632,12 @@ where
     V: Smt2Visitor,
 {
     type T = V::QualIdentifier;
+    type E = R::Error;
 
-    fn visit_simple_identifier(&mut self, identifier: Identifier<V::Symbol>) -> Self::T {
+    fn visit_simple_identifier(
+        &mut self,
+        identifier: Identifier<V::Symbol>,
+    ) -> Result<Self::T, Self::E> {
         self.visit_simple_identifier(identifier)
     }
 
@@ -601,7 +645,7 @@ where
         &mut self,
         identifier: Identifier<V::Symbol>,
         sort: V::Sort,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_sorted_identifier(identifier, sort)
     }
 }
@@ -613,12 +657,16 @@ where
     V: Smt2Visitor,
 {
     type T = V::Term;
+    type E = R::Error;
 
-    fn visit_constant(&mut self, constant: V::Constant) -> Self::T {
+    fn visit_constant(&mut self, constant: V::Constant) -> Result<Self::T, Self::E> {
         self.visit_constant(constant)
     }
 
-    fn visit_qual_identifier(&mut self, qual_identifier: V::QualIdentifier) -> Self::T {
+    fn visit_qual_identifier(
+        &mut self,
+        qual_identifier: V::QualIdentifier,
+    ) -> Result<Self::T, Self::E> {
         self.visit_qual_identifier(qual_identifier)
     }
 
@@ -626,23 +674,39 @@ where
         &mut self,
         qual_identifier: V::QualIdentifier,
         arguments: Vec<Self::T>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_application(qual_identifier, arguments)
     }
 
-    fn visit_let(&mut self, var_bindings: Vec<(V::Symbol, Self::T)>, term: Self::T) -> Self::T {
+    fn visit_let(
+        &mut self,
+        var_bindings: Vec<(V::Symbol, Self::T)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
         self.visit_let(var_bindings, term)
     }
 
-    fn visit_forall(&mut self, vars: Vec<(V::Symbol, V::Sort)>, term: Self::T) -> Self::T {
+    fn visit_forall(
+        &mut self,
+        vars: Vec<(V::Symbol, V::Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
         self.visit_forall(vars, term)
     }
 
-    fn visit_exists(&mut self, vars: Vec<(V::Symbol, V::Sort)>, term: Self::T) -> Self::T {
+    fn visit_exists(
+        &mut self,
+        vars: Vec<(V::Symbol, V::Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
         self.visit_exists(vars, term)
     }
 
-    fn visit_match(&mut self, term: Self::T, cases: Vec<(Vec<V::Symbol>, Self::T)>) -> Self::T {
+    fn visit_match(
+        &mut self,
+        term: Self::T,
+        cases: Vec<(Vec<V::Symbol>, Self::T)>,
+    ) -> Result<Self::T, Self::E> {
         self.visit_match(term, cases)
     }
 
@@ -650,7 +714,7 @@ where
         &mut self,
         term: Self::T,
         attributes: Vec<(V::Keyword, AttributeValue<V::Constant, V::Symbol, V::SExpr>)>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_attributes(term, attributes)
     }
 }
@@ -661,20 +725,28 @@ where
     V: Smt2Visitor,
 {
     type T = V::Command;
+    type E = R::Error;
 
-    fn visit_assert(&mut self, term: V::Term) -> Self::T {
+    fn visit_assert(&mut self, term: V::Term) -> Result<Self::T, Self::E> {
         self.visit_assert(term)
     }
 
-    fn visit_check_sat(&mut self) -> Self::T {
+    fn visit_check_sat(&mut self) -> Result<Self::T, Self::E> {
         self.visit_check_sat()
     }
 
-    fn visit_check_sat_assuming(&mut self, literals: Vec<(V::Symbol, bool)>) -> Self::T {
+    fn visit_check_sat_assuming(
+        &mut self,
+        literals: Vec<(V::Symbol, bool)>,
+    ) -> Result<Self::T, Self::E> {
         self.visit_check_sat_assuming(literals)
     }
 
-    fn visit_declare_const(&mut self, symbol: V::Symbol, sort: V::Sort) -> Self::T {
+    fn visit_declare_const(
+        &mut self,
+        symbol: V::Symbol,
+        sort: V::Sort,
+    ) -> Result<Self::T, Self::E> {
         self.visit_declare_const(symbol, sort)
     }
 
@@ -682,14 +754,14 @@ where
         &mut self,
         symbol: V::Symbol,
         datatype: DatatypeDec<V::Symbol, V::Sort>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_declare_datatype(symbol, datatype)
     }
 
     fn visit_declare_datatypes(
         &mut self,
         datatypes: Vec<(V::Symbol, Numeral, DatatypeDec<V::Symbol, V::Sort>)>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_declare_datatypes(datatypes)
     }
 
@@ -698,15 +770,23 @@ where
         symbol: V::Symbol,
         parameters: Vec<V::Sort>,
         sort: V::Sort,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_declare_fun(symbol, parameters, sort)
     }
 
-    fn visit_declare_sort(&mut self, symbol: V::Symbol, arity: Numeral) -> Self::T {
+    fn visit_declare_sort(
+        &mut self,
+        symbol: V::Symbol,
+        arity: Numeral,
+    ) -> Result<Self::T, Self::E> {
         self.visit_declare_sort(symbol, arity)
     }
 
-    fn visit_define_fun(&mut self, sig: FunctionDec<V::Symbol, V::Sort>, term: V::Term) -> Self::T {
+    fn visit_define_fun(
+        &mut self,
+        sig: FunctionDec<V::Symbol, V::Sort>,
+        term: V::Term,
+    ) -> Result<Self::T, Self::E> {
         self.visit_define_fun(sig, term)
     }
 
@@ -714,14 +794,14 @@ where
         &mut self,
         sig: FunctionDec<V::Symbol, V::Sort>,
         term: V::Term,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_define_fun_rec(sig, term)
     }
 
     fn visit_define_funs_rec(
         &mut self,
         funs: Vec<(FunctionDec<V::Symbol, V::Sort>, V::Term)>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_define_funs_rec(funs)
     }
 
@@ -730,67 +810,67 @@ where
         symbol: V::Symbol,
         parameters: Vec<V::Symbol>,
         sort: V::Sort,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_define_sort(symbol, parameters, sort)
     }
 
-    fn visit_echo(&mut self, message: String) -> Self::T {
+    fn visit_echo(&mut self, message: String) -> Result<Self::T, Self::E> {
         self.visit_echo(message)
     }
 
-    fn visit_exit(&mut self) -> Self::T {
+    fn visit_exit(&mut self) -> Result<Self::T, Self::E> {
         self.visit_exit()
     }
 
-    fn visit_get_assertions(&mut self) -> Self::T {
+    fn visit_get_assertions(&mut self) -> Result<Self::T, Self::E> {
         self.visit_get_assertions()
     }
 
-    fn visit_get_assignment(&mut self) -> Self::T {
+    fn visit_get_assignment(&mut self) -> Result<Self::T, Self::E> {
         self.visit_get_assignment()
     }
 
-    fn visit_get_info(&mut self, flag: V::Keyword) -> Self::T {
+    fn visit_get_info(&mut self, flag: V::Keyword) -> Result<Self::T, Self::E> {
         self.visit_get_info(flag)
     }
 
-    fn visit_get_model(&mut self) -> Self::T {
+    fn visit_get_model(&mut self) -> Result<Self::T, Self::E> {
         self.visit_get_model()
     }
 
-    fn visit_get_option(&mut self, keyword: V::Keyword) -> Self::T {
+    fn visit_get_option(&mut self, keyword: V::Keyword) -> Result<Self::T, Self::E> {
         self.visit_get_option(keyword)
     }
 
-    fn visit_get_proof(&mut self) -> Self::T {
+    fn visit_get_proof(&mut self) -> Result<Self::T, Self::E> {
         self.visit_get_proof()
     }
 
-    fn visit_get_unsat_assumptions(&mut self) -> Self::T {
+    fn visit_get_unsat_assumptions(&mut self) -> Result<Self::T, Self::E> {
         self.visit_get_unsat_assumptions()
     }
 
-    fn visit_get_unsat_core(&mut self) -> Self::T {
+    fn visit_get_unsat_core(&mut self) -> Result<Self::T, Self::E> {
         self.visit_get_unsat_core()
     }
 
-    fn visit_get_value(&mut self, terms: Vec<V::Term>) -> Self::T {
+    fn visit_get_value(&mut self, terms: Vec<V::Term>) -> Result<Self::T, Self::E> {
         self.visit_get_value(terms)
     }
 
-    fn visit_pop(&mut self, level: Numeral) -> Self::T {
+    fn visit_pop(&mut self, level: Numeral) -> Result<Self::T, Self::E> {
         self.visit_pop(level)
     }
 
-    fn visit_push(&mut self, level: Numeral) -> Self::T {
+    fn visit_push(&mut self, level: Numeral) -> Result<Self::T, Self::E> {
         self.visit_push(level)
     }
 
-    fn visit_reset(&mut self) -> Self::T {
+    fn visit_reset(&mut self) -> Result<Self::T, Self::E> {
         self.visit_reset()
     }
 
-    fn visit_reset_assertions(&mut self) -> Self::T {
+    fn visit_reset_assertions(&mut self) -> Result<Self::T, Self::E> {
         self.visit_reset_assertions()
     }
 
@@ -798,11 +878,11 @@ where
         &mut self,
         keyword: V::Keyword,
         value: AttributeValue<V::Constant, V::Symbol, V::SExpr>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_set_info(keyword, value)
     }
 
-    fn visit_set_logic(&mut self, symbol: V::Symbol) -> Self::T {
+    fn visit_set_logic(&mut self, symbol: V::Symbol) -> Result<Self::T, Self::E> {
         self.visit_set_logic(symbol)
     }
 
@@ -810,7 +890,7 @@ where
         &mut self,
         keyword: V::Keyword,
         value: AttributeValue<V::Constant, V::Symbol, V::SExpr>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.visit_set_option(keyword, value)
     }
 }
@@ -820,6 +900,7 @@ where
     R: Rewriter<V = V>,
     V: Smt2Visitor,
 {
+    type Error = R::Error;
     type Constant = V::Constant;
     type QualIdentifier = V::QualIdentifier;
     type Keyword = V::Keyword;
@@ -828,6 +909,14 @@ where
     type Symbol = V::Symbol;
     type Term = V::Term;
     type Command = V::Command;
+
+    fn syntax_error(&mut self) -> Self::Error {
+        self.visitor().syntax_error().into()
+    }
+
+    fn parsing_error(&mut self, s: String) -> Self::Error {
+        self.visitor().parsing_error(s).into()
+    }
 }
 
 #[test]
@@ -877,19 +966,20 @@ fn test_term_rewriter() {
     struct Builder(crate::concrete::SyntaxBuilder);
     impl Rewriter for Builder {
         type V = crate::concrete::SyntaxBuilder;
+        type Error = crate::concrete::Error;
 
         fn visitor(&mut self) -> &mut Self::V {
             &mut self.0
         }
 
-        fn process_symbol(&mut self, s: Symbol) -> Symbol {
-            Symbol(s.0 + "__")
+        fn process_symbol(&mut self, s: Symbol) -> Result<Symbol, Self::Error> {
+            Ok(Symbol(s.0 + "__"))
         }
     }
 
     let mut builder = Builder::default();
 
-    let command2 = command.clone().accept(&mut builder);
+    let command2 = command.clone().accept(&mut builder).unwrap();
     let command3 = Command::Assert {
         term: Term::Let {
             var_bindings: vec![(
@@ -934,19 +1024,20 @@ fn test_term_rewriter() {
     struct Builder2(crate::concrete::SyntaxBuilder);
     impl Rewriter for Builder2 {
         type V = crate::concrete::SyntaxBuilder;
+        type Error = crate::concrete::Error;
 
         fn visitor(&mut self) -> &mut Self::V {
             &mut self.0
         }
 
-        fn visit_assert(&mut self, _: Term) -> Command {
-            Command::Exit
+        fn visit_assert(&mut self, _: Term) -> Result<Command, Self::Error> {
+            Ok(Command::Exit)
         }
     }
 
     let mut builder = Builder2::default();
 
-    let command2 = command.accept(&mut builder);
+    let command2 = command.accept(&mut builder).unwrap();
     let command3 = Command::Exit;
     assert_eq!(command2, command3);
 }

--- a/smt2parser/src/rewriter.rs
+++ b/smt2parser/src/rewriter.rs
@@ -11,7 +11,7 @@ use crate::{
         KeywordVisitor, QualIdentifierVisitor, SExprVisitor, Smt2Visitor, SortVisitor,
         SymbolVisitor, TermVisitor,
     },
-    Binary, Decimal, Hexadecimal, Numeral,
+    Binary, Decimal, Hexadecimal, Numeral, Position,
 };
 
 /// Helper trait to create variants of an existing Smt2Visitor.
@@ -910,12 +910,12 @@ where
     type Term = V::Term;
     type Command = V::Command;
 
-    fn syntax_error(&mut self) -> Self::Error {
-        self.visitor().syntax_error().into()
+    fn syntax_error(&mut self, pos: Position, s: String) -> Self::Error {
+        self.visitor().syntax_error(pos, s).into()
     }
 
-    fn parsing_error(&mut self, s: String) -> Self::Error {
-        self.visitor().parsing_error(s).into()
+    fn parsing_error(&mut self, pos: Position, s: String) -> Self::Error {
+        self.visitor().parsing_error(pos, s).into()
     }
 }
 

--- a/smt2parser/src/stats.rs
+++ b/smt2parser/src/stats.rs
@@ -136,48 +136,59 @@ impl Term {
 
 impl ConstantVisitor for Smt2Counters {
     type T = ();
+    type E = crate::concrete::Error;
 
-    fn visit_numeral_constant(&mut self, _value: Numeral) -> Self::T {
+    fn visit_numeral_constant(&mut self, _value: Numeral) -> Result<Self::T, Self::E> {
         self.numeral_constant_count += 1;
+        Ok(())
     }
-    fn visit_decimal_constant(&mut self, _value: Decimal) -> Self::T {
+    fn visit_decimal_constant(&mut self, _value: Decimal) -> Result<Self::T, Self::E> {
         self.decimal_constant_count += 1;
+        Ok(())
     }
-    fn visit_hexadecimal_constant(&mut self, _value: Hexadecimal) -> Self::T {
+    fn visit_hexadecimal_constant(&mut self, _value: Hexadecimal) -> Result<Self::T, Self::E> {
         self.hexadecimal_constant_count += 1;
+        Ok(())
     }
-    fn visit_binary_constant(&mut self, _value: Binary) -> Self::T {
+    fn visit_binary_constant(&mut self, _value: Binary) -> Result<Self::T, Self::E> {
         self.binary_constant_count += 1;
+        Ok(())
     }
-    fn visit_string_constant(&mut self, _value: String) -> Self::T {
+    fn visit_string_constant(&mut self, _value: String) -> Result<Self::T, Self::E> {
         self.string_constant_count += 1;
+        Ok(())
     }
 }
 
 impl SymbolVisitor for Smt2Counters {
     type T = ();
+    type E = crate::concrete::Error;
 
-    fn visit_fresh_symbol(&mut self, _value: String) -> Self::T {
+    fn visit_fresh_symbol(&mut self, _value: String) -> Result<Self::T, Self::E> {
         self.fresh_symbol_count += 1;
+        Ok(())
     }
 
-    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, String> {
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
         self.bound_symbol_count += 1;
         self.visit_symbol(&value);
         Ok(())
     }
 
-    fn visit_any_symbol(&mut self, _value: String) -> Self::T {
+    fn visit_any_symbol(&mut self, _value: String) -> Result<Self::T, Self::E> {
         self.any_symbol_count += 1;
+        Ok(())
     }
 }
 
 impl KeywordVisitor for Smt2Counters {
     type T = ();
+    type E = crate::concrete::Error;
 
-    fn visit_keyword(&mut self, value: String) -> Self::T {
+    fn visit_keyword(&mut self, value: String) -> Result<Self::T, Self::E> {
         self.keyword_count += 1;
         self.visit_keyword(&value);
+        Ok(())
     }
 }
 
@@ -195,101 +206,140 @@ type FunctionDec = crate::visitors::FunctionDec<Symbol, Sort>;
 
 impl SExprVisitor<Constant, Symbol, Keyword> for Smt2Counters {
     type T = ();
+    type E = crate::concrete::Error;
 
-    fn visit_constant_s_expr(&mut self, _value: Constant) -> Self::T {
+    fn visit_constant_s_expr(&mut self, _value: Constant) -> Result<Self::T, Self::E> {
         self.constant_s_expr_count += 1;
+        Ok(())
     }
 
-    fn visit_symbol_s_expr(&mut self, _value: Symbol) -> Self::T {
+    fn visit_symbol_s_expr(&mut self, _value: Symbol) -> Result<Self::T, Self::E> {
         self.symbol_s_expr_count += 1;
+        Ok(())
     }
 
-    fn visit_keyword_s_expr(&mut self, _value: Keyword) -> Self::T {
+    fn visit_keyword_s_expr(&mut self, _value: Keyword) -> Result<Self::T, Self::E> {
         self.keyword_s_expr_count += 1;
+        Ok(())
     }
 
-    fn visit_application_s_expr(&mut self, _values: Vec<Self::T>) -> Self::T {
+    fn visit_application_s_expr(&mut self, _values: Vec<Self::T>) -> Result<Self::T, Self::E> {
         self.application_s_expr_count += 1;
+        Ok(())
     }
 }
 
 impl SortVisitor<Symbol> for Smt2Counters {
     type T = ();
+    type E = crate::concrete::Error;
 
-    fn visit_simple_sort(&mut self, _identifier: Identifier) -> Self::T {
+    fn visit_simple_sort(&mut self, _identifier: Identifier) -> Result<Self::T, Self::E> {
         self.simple_sort_count += 1;
+        Ok(())
     }
 
     fn visit_parameterized_sort(
         &mut self,
         _identifier: Identifier,
         _parameters: Vec<Self::T>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.parameterized_sort_count += 1;
+        Ok(())
     }
 }
 
 impl QualIdentifierVisitor<Identifier, Sort> for Smt2Counters {
     type T = ();
+    type E = crate::concrete::Error;
 
-    fn visit_simple_identifier(&mut self, _identifier: Identifier) -> Self::T {
+    fn visit_simple_identifier(&mut self, _identifier: Identifier) -> Result<Self::T, Self::E> {
         self.simple_identifier_count += 1;
+        Ok(())
     }
 
-    fn visit_sorted_identifier(&mut self, _identifier: Identifier, _sort: Sort) -> Self::T {
+    fn visit_sorted_identifier(
+        &mut self,
+        _identifier: Identifier,
+        _sort: Sort,
+    ) -> Result<Self::T, Self::E> {
         self.sorted_identifier_count += 1;
+        Ok(())
     }
 }
 
 impl TermVisitor<Constant, QualIdentifier, Keyword, SExpr, Symbol, Sort> for Smt2Counters {
     type T = Term;
+    type E = crate::concrete::Error;
 
-    fn visit_constant(&mut self, _constant: Constant) -> Self::T {
+    fn visit_constant(&mut self, _constant: Constant) -> Result<Self::T, Self::E> {
         self.constant_count += 1;
-        Term::default()
+        Ok(Term::default())
     }
 
-    fn visit_qual_identifier(&mut self, _qual_identifier: QualIdentifier) -> Self::T {
+    fn visit_qual_identifier(
+        &mut self,
+        _qual_identifier: QualIdentifier,
+    ) -> Result<Self::T, Self::E> {
         self.qual_identifier_count += 1;
-        Term::default()
+        Ok(Term::default())
     }
 
     fn visit_application(
         &mut self,
         _qual_identifier: QualIdentifier,
         arguments: Vec<Self::T>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.application_count += 1;
-        Term::node(arguments.into_iter())
+        Ok(Term::node(arguments.into_iter()))
     }
 
-    fn visit_let(&mut self, var_bindings: Vec<(Symbol, Self::T)>, term: Self::T) -> Self::T {
+    fn visit_let(
+        &mut self,
+        var_bindings: Vec<(Symbol, Self::T)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
         self.let_count += 1;
-        Term::node(std::iter::once(term).chain(var_bindings.into_iter().map(|(_, t)| t)))
+        Ok(Term::node(
+            std::iter::once(term).chain(var_bindings.into_iter().map(|(_, t)| t)),
+        ))
     }
 
-    fn visit_forall(&mut self, _vars: Vec<(Symbol, Sort)>, term: Self::T) -> Self::T {
+    fn visit_forall(
+        &mut self,
+        _vars: Vec<(Symbol, Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
         self.forall_count += 1;
-        Term::node(std::iter::once(term))
+        Ok(Term::node(std::iter::once(term)))
     }
 
-    fn visit_exists(&mut self, _vars: Vec<(Symbol, Sort)>, term: Self::T) -> Self::T {
+    fn visit_exists(
+        &mut self,
+        _vars: Vec<(Symbol, Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
         self.exists_count += 1;
-        Term::node(std::iter::once(term))
+        Ok(Term::node(std::iter::once(term)))
     }
 
-    fn visit_match(&mut self, term: Self::T, cases: Vec<(Vec<Symbol>, Self::T)>) -> Self::T {
+    fn visit_match(
+        &mut self,
+        term: Self::T,
+        cases: Vec<(Vec<Symbol>, Self::T)>,
+    ) -> Result<Self::T, Self::E> {
         self.match_count += 1;
-        Term::node(std::iter::once(term).chain(cases.into_iter().map(|(_, t)| t)))
+        Ok(Term::node(
+            std::iter::once(term).chain(cases.into_iter().map(|(_, t)| t)),
+        ))
     }
 
     fn visit_attributes(
         &mut self,
         term: Self::T,
         _attributes: Vec<(Keyword, AttributeValue)>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.attributes_count += 1;
-        Term::node(std::iter::once(term))
+        Ok(Term::node(std::iter::once(term)))
     }
 }
 
@@ -305,33 +355,47 @@ impl Smt2Counters {
 
 impl CommandVisitor<Term, Symbol, Sort, Keyword, Constant, SExpr> for Smt2Counters {
     type T = ();
+    type E = crate::concrete::Error;
 
-    fn visit_assert(&mut self, term: Term) -> Self::T {
+    fn visit_assert(&mut self, term: Term) -> Result<Self::T, Self::E> {
         self.assert_count += 1;
-        self.visit_term(term)
+        self.visit_term(term);
+        Ok(())
     }
 
-    fn visit_check_sat(&mut self) -> Self::T {
+    fn visit_check_sat(&mut self) -> Result<Self::T, Self::E> {
         self.check_sat_count += 1;
+        Ok(())
     }
 
-    fn visit_check_sat_assuming(&mut self, _literals: Vec<(Symbol, bool)>) -> Self::T {
+    fn visit_check_sat_assuming(
+        &mut self,
+        _literals: Vec<(Symbol, bool)>,
+    ) -> Result<Self::T, Self::E> {
         self.check_sat_assuming_count += 1;
+        Ok(())
     }
 
-    fn visit_declare_const(&mut self, _symbol: Symbol, _sort: Sort) -> Self::T {
+    fn visit_declare_const(&mut self, _symbol: Symbol, _sort: Sort) -> Result<Self::T, Self::E> {
         self.declare_const_count += 1;
+        Ok(())
     }
 
-    fn visit_declare_datatype(&mut self, _symbol: Symbol, _datatype: DatatypeDec) -> Self::T {
+    fn visit_declare_datatype(
+        &mut self,
+        _symbol: Symbol,
+        _datatype: DatatypeDec,
+    ) -> Result<Self::T, Self::E> {
         self.declare_datatype_count += 1;
+        Ok(())
     }
 
     fn visit_declare_datatypes(
         &mut self,
         _datatypes: Vec<(Symbol, Numeral, DatatypeDec)>,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.declare_datatypes_count += 1;
+        Ok(())
     }
 
     fn visit_declare_fun(
@@ -339,29 +403,37 @@ impl CommandVisitor<Term, Symbol, Sort, Keyword, Constant, SExpr> for Smt2Counte
         _symbol: Symbol,
         _parameters: Vec<Sort>,
         _sort: Sort,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.declare_fun_count += 1;
+        Ok(())
     }
 
-    fn visit_declare_sort(&mut self, _symbol: Symbol, _arity: Numeral) -> Self::T {
+    fn visit_declare_sort(&mut self, _symbol: Symbol, _arity: Numeral) -> Result<Self::T, Self::E> {
         self.declare_sort_count += 1;
+        Ok(())
     }
 
-    fn visit_define_fun(&mut self, _sig: FunctionDec, term: Term) -> Self::T {
+    fn visit_define_fun(&mut self, _sig: FunctionDec, term: Term) -> Result<Self::T, Self::E> {
         self.define_fun_count += 1;
-        self.visit_term(term)
+        self.visit_term(term);
+        Ok(())
     }
 
-    fn visit_define_fun_rec(&mut self, _sig: FunctionDec, term: Term) -> Self::T {
+    fn visit_define_fun_rec(&mut self, _sig: FunctionDec, term: Term) -> Result<Self::T, Self::E> {
         self.define_fun_rec_count += 1;
-        self.visit_term(term)
+        self.visit_term(term);
+        Ok(())
     }
 
-    fn visit_define_funs_rec(&mut self, funs: Vec<(FunctionDec, Term)>) -> Self::T {
+    fn visit_define_funs_rec(
+        &mut self,
+        funs: Vec<(FunctionDec, Term)>,
+    ) -> Result<Self::T, Self::E> {
         self.define_funs_rec_count += 1;
         for (_, term) in funs {
             self.visit_term(term);
         }
+        Ok(())
     }
 
     fn visit_define_sort(
@@ -369,87 +441,115 @@ impl CommandVisitor<Term, Symbol, Sort, Keyword, Constant, SExpr> for Smt2Counte
         _symbol: Symbol,
         _parameters: Vec<Symbol>,
         _sort: Sort,
-    ) -> Self::T {
+    ) -> Result<Self::T, Self::E> {
         self.define_sort_count += 1;
+        Ok(())
     }
 
-    fn visit_echo(&mut self, _message: String) -> Self::T {
+    fn visit_echo(&mut self, _message: String) -> Result<Self::T, Self::E> {
         self.echo_count += 1;
+        Ok(())
     }
 
-    fn visit_exit(&mut self) -> Self::T {
+    fn visit_exit(&mut self) -> Result<Self::T, Self::E> {
         self.exit_count += 1;
+        Ok(())
     }
 
-    fn visit_get_assertions(&mut self) -> Self::T {
+    fn visit_get_assertions(&mut self) -> Result<Self::T, Self::E> {
         self.get_assertions_count += 1;
+        Ok(())
     }
 
-    fn visit_get_assignment(&mut self) -> Self::T {
+    fn visit_get_assignment(&mut self) -> Result<Self::T, Self::E> {
         self.get_assignment_count += 1;
+        Ok(())
     }
 
-    fn visit_get_info(&mut self, _flag: Keyword) -> Self::T {
+    fn visit_get_info(&mut self, _flag: Keyword) -> Result<Self::T, Self::E> {
         self.get_info_count += 1;
+        Ok(())
     }
 
-    fn visit_get_model(&mut self) -> Self::T {
+    fn visit_get_model(&mut self) -> Result<Self::T, Self::E> {
         self.get_model_count += 1;
+        Ok(())
     }
 
-    fn visit_get_option(&mut self, _keyword: Keyword) -> Self::T {
+    fn visit_get_option(&mut self, _keyword: Keyword) -> Result<Self::T, Self::E> {
         self.get_option_count += 1;
+        Ok(())
     }
 
-    fn visit_get_proof(&mut self) -> Self::T {
+    fn visit_get_proof(&mut self) -> Result<Self::T, Self::E> {
         self.get_proof_count += 1;
+        Ok(())
     }
 
-    fn visit_get_unsat_assumptions(&mut self) -> Self::T {
+    fn visit_get_unsat_assumptions(&mut self) -> Result<Self::T, Self::E> {
         self.get_unsat_assumptions_count += 1;
+        Ok(())
     }
 
-    fn visit_get_unsat_core(&mut self) -> Self::T {
+    fn visit_get_unsat_core(&mut self) -> Result<Self::T, Self::E> {
         self.get_unsat_core_count += 1;
+        Ok(())
     }
 
-    fn visit_get_value(&mut self, terms: Vec<Term>) -> Self::T {
+    fn visit_get_value(&mut self, terms: Vec<Term>) -> Result<Self::T, Self::E> {
         self.get_value_count += 1;
         for term in terms {
             self.visit_term(term);
         }
+        Ok(())
     }
 
-    fn visit_pop(&mut self, _level: Numeral) -> Self::T {
+    fn visit_pop(&mut self, _level: Numeral) -> Result<Self::T, Self::E> {
         self.pop_count += 1;
+        Ok(())
     }
 
-    fn visit_push(&mut self, _level: Numeral) -> Self::T {
+    fn visit_push(&mut self, _level: Numeral) -> Result<Self::T, Self::E> {
         self.push_count += 1;
+        Ok(())
     }
 
-    fn visit_reset(&mut self) -> Self::T {
+    fn visit_reset(&mut self) -> Result<Self::T, Self::E> {
         self.reset_count += 1;
+        Ok(())
     }
 
-    fn visit_reset_assertions(&mut self) -> Self::T {
+    fn visit_reset_assertions(&mut self) -> Result<Self::T, Self::E> {
         self.reset_assertions_count += 1;
+        Ok(())
     }
 
-    fn visit_set_info(&mut self, _keyword: Keyword, _value: AttributeValue) -> Self::T {
+    fn visit_set_info(
+        &mut self,
+        _keyword: Keyword,
+        _value: AttributeValue,
+    ) -> Result<Self::T, Self::E> {
         self.set_info_count += 1;
+        Ok(())
     }
 
-    fn visit_set_logic(&mut self, _symbol: Symbol) -> Self::T {
+    fn visit_set_logic(&mut self, _symbol: Symbol) -> Result<Self::T, Self::E> {
         self.set_logic_count += 1;
+        Ok(())
     }
 
-    fn visit_set_option(&mut self, _keyword: Keyword, _value: AttributeValue) -> Self::T {
+    fn visit_set_option(
+        &mut self,
+        _keyword: Keyword,
+        _value: AttributeValue,
+    ) -> Result<Self::T, Self::E> {
         self.set_option_count += 1;
+        Ok(())
     }
 }
 
 impl Smt2Visitor for Smt2Counters {
+    type Error = crate::concrete::Error;
     type Constant = ();
     type QualIdentifier = ();
     type Keyword = ();
@@ -458,4 +558,12 @@ impl Smt2Visitor for Smt2Counters {
     type Symbol = ();
     type Term = Term;
     type Command = ();
+
+    fn syntax_error(&mut self) -> Self::Error {
+        crate::concrete::Error::SyntaxError
+    }
+
+    fn parsing_error(&mut self, s: String) -> Self::Error {
+        crate::concrete::Error::ParsingError(s)
+    }
 }

--- a/smt2parser/src/stats.rs
+++ b/smt2parser/src/stats.rs
@@ -4,11 +4,12 @@
 //! A demo implementation of visiting traits that counts things.
 
 use crate::{
+    concrete::Error,
     visitors::{
         CommandVisitor, ConstantVisitor, KeywordVisitor, QualIdentifierVisitor, SExprVisitor,
         Smt2Visitor, SortVisitor, SymbolVisitor, TermVisitor,
     },
-    Binary, Decimal, Hexadecimal, Numeral,
+    Binary, Decimal, Hexadecimal, Numeral, Position,
 };
 
 use serde::{Deserialize, Serialize};
@@ -136,7 +137,7 @@ impl Term {
 
 impl ConstantVisitor for Smt2Counters {
     type T = ();
-    type E = crate::concrete::Error;
+    type E = Error;
 
     fn visit_numeral_constant(&mut self, _value: Numeral) -> Result<Self::T, Self::E> {
         self.numeral_constant_count += 1;
@@ -162,7 +163,7 @@ impl ConstantVisitor for Smt2Counters {
 
 impl SymbolVisitor for Smt2Counters {
     type T = ();
-    type E = crate::concrete::Error;
+    type E = Error;
 
     fn visit_fresh_symbol(&mut self, _value: String) -> Result<Self::T, Self::E> {
         self.fresh_symbol_count += 1;
@@ -183,7 +184,7 @@ impl SymbolVisitor for Smt2Counters {
 
 impl KeywordVisitor for Smt2Counters {
     type T = ();
-    type E = crate::concrete::Error;
+    type E = Error;
 
     fn visit_keyword(&mut self, value: String) -> Result<Self::T, Self::E> {
         self.keyword_count += 1;
@@ -206,7 +207,7 @@ type FunctionDec = crate::visitors::FunctionDec<Symbol, Sort>;
 
 impl SExprVisitor<Constant, Symbol, Keyword> for Smt2Counters {
     type T = ();
-    type E = crate::concrete::Error;
+    type E = Error;
 
     fn visit_constant_s_expr(&mut self, _value: Constant) -> Result<Self::T, Self::E> {
         self.constant_s_expr_count += 1;
@@ -231,7 +232,7 @@ impl SExprVisitor<Constant, Symbol, Keyword> for Smt2Counters {
 
 impl SortVisitor<Symbol> for Smt2Counters {
     type T = ();
-    type E = crate::concrete::Error;
+    type E = Error;
 
     fn visit_simple_sort(&mut self, _identifier: Identifier) -> Result<Self::T, Self::E> {
         self.simple_sort_count += 1;
@@ -250,7 +251,7 @@ impl SortVisitor<Symbol> for Smt2Counters {
 
 impl QualIdentifierVisitor<Identifier, Sort> for Smt2Counters {
     type T = ();
-    type E = crate::concrete::Error;
+    type E = Error;
 
     fn visit_simple_identifier(&mut self, _identifier: Identifier) -> Result<Self::T, Self::E> {
         self.simple_identifier_count += 1;
@@ -269,7 +270,7 @@ impl QualIdentifierVisitor<Identifier, Sort> for Smt2Counters {
 
 impl TermVisitor<Constant, QualIdentifier, Keyword, SExpr, Symbol, Sort> for Smt2Counters {
     type T = Term;
-    type E = crate::concrete::Error;
+    type E = Error;
 
     fn visit_constant(&mut self, _constant: Constant) -> Result<Self::T, Self::E> {
         self.constant_count += 1;
@@ -355,7 +356,7 @@ impl Smt2Counters {
 
 impl CommandVisitor<Term, Symbol, Sort, Keyword, Constant, SExpr> for Smt2Counters {
     type T = ();
-    type E = crate::concrete::Error;
+    type E = Error;
 
     fn visit_assert(&mut self, term: Term) -> Result<Self::T, Self::E> {
         self.assert_count += 1;
@@ -549,7 +550,7 @@ impl CommandVisitor<Term, Symbol, Sort, Keyword, Constant, SExpr> for Smt2Counte
 }
 
 impl Smt2Visitor for Smt2Counters {
-    type Error = crate::concrete::Error;
+    type Error = Error;
     type Constant = ();
     type QualIdentifier = ();
     type Keyword = ();
@@ -559,11 +560,11 @@ impl Smt2Visitor for Smt2Counters {
     type Term = Term;
     type Command = ();
 
-    fn syntax_error(&mut self) -> Self::Error {
-        crate::concrete::Error::SyntaxError
+    fn syntax_error(&mut self, position: Position, s: String) -> Self::Error {
+        Error::SyntaxError(position, s)
     }
 
-    fn parsing_error(&mut self, s: String) -> Self::Error {
-        crate::concrete::Error::ParsingError(s)
+    fn parsing_error(&mut self, position: Position, s: String) -> Self::Error {
+        Error::ParsingError(position, s)
     }
 }

--- a/smt2parser/src/visitors.rs
+++ b/smt2parser/src/visitors.rs
@@ -466,8 +466,8 @@ pub trait Smt2Visitor:
     type Term;
     type Command;
 
-    fn syntax_error(&mut self) -> Self::Error;
-    fn parsing_error(&mut self, s: String) -> Self::Error;
+    fn syntax_error(&mut self, position: crate::Position, s: String) -> Self::Error;
+    fn parsing_error(&mut self, position: crate::Position, s: String) -> Self::Error;
 }
 
 impl<Symbol> std::fmt::Display for Index<Symbol>

--- a/smt2parser/src/visitors.rs
+++ b/smt2parser/src/visitors.rs
@@ -9,28 +9,29 @@ use serde::{Deserialize, Serialize};
 
 pub trait ConstantVisitor {
     type T;
+    type E;
 
-    fn visit_numeral_constant(&mut self, value: Numeral) -> Self::T;
-    fn visit_decimal_constant(&mut self, value: Decimal) -> Self::T;
-    fn visit_hexadecimal_constant(&mut self, value: Hexadecimal) -> Self::T;
-    fn visit_binary_constant(&mut self, value: Binary) -> Self::T;
-    fn visit_string_constant(&mut self, value: String) -> Self::T;
+    fn visit_numeral_constant(&mut self, value: Numeral) -> Result<Self::T, Self::E>;
+    fn visit_decimal_constant(&mut self, value: Decimal) -> Result<Self::T, Self::E>;
+    fn visit_hexadecimal_constant(&mut self, value: Hexadecimal) -> Result<Self::T, Self::E>;
+    fn visit_binary_constant(&mut self, value: Binary) -> Result<Self::T, Self::E>;
+    fn visit_string_constant(&mut self, value: String) -> Result<Self::T, Self::E>;
 }
 
 pub trait SymbolVisitor {
     type T;
+    type E;
 
-    fn visit_fresh_symbol(&mut self, value: String) -> Self::T;
+    fn visit_fresh_symbol(&mut self, value: String) -> Result<Self::T, Self::E>;
 
-    // If it is not a valid bound symbol, return an error containing the value.
-    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, String> {
-        Ok(self.visit_fresh_symbol(value))
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
+        self.visit_fresh_symbol(value)
     }
 
-    // If it is not a valid bound symbol, create a fresh one.
-    fn visit_any_symbol(&mut self, value: String) -> Self::T {
-        self.visit_bound_symbol(value)
-            .unwrap_or_else(|v| self.visit_fresh_symbol(v))
+    // If the symbol is not a valid bound symbol, try to create a fresh one.
+    fn visit_any_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
+        self.visit_bound_symbol(value.clone())
+            .or_else(|_| self.visit_fresh_symbol(value))
     }
 
     fn bind_symbol(&mut self, _symbol: &Self::T) {}
@@ -40,17 +41,19 @@ pub trait SymbolVisitor {
 
 pub trait KeywordVisitor {
     type T;
+    type E;
 
-    fn visit_keyword(&mut self, value: String) -> Self::T;
+    fn visit_keyword(&mut self, value: String) -> Result<Self::T, Self::E>;
 }
 
 pub trait SExprVisitor<Constant, Symbol, Keyword> {
     type T;
+    type E;
 
-    fn visit_constant_s_expr(&mut self, value: Constant) -> Self::T;
-    fn visit_symbol_s_expr(&mut self, value: Symbol) -> Self::T;
-    fn visit_keyword_s_expr(&mut self, value: Keyword) -> Self::T;
-    fn visit_application_s_expr(&mut self, values: Vec<Self::T>) -> Self::T;
+    fn visit_constant_s_expr(&mut self, value: Constant) -> Result<Self::T, Self::E>;
+    fn visit_symbol_s_expr(&mut self, value: Symbol) -> Result<Self::T, Self::E>;
+    fn visit_keyword_s_expr(&mut self, value: Keyword) -> Result<Self::T, Self::E>;
+    fn visit_application_s_expr(&mut self, values: Vec<Self::T>) -> Result<Self::T, Self::E>;
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
@@ -61,14 +64,14 @@ pub enum Index<Symbol> {
 
 impl<S> Index<S> {
     /// Remap the symbols of an Index value.
-    pub(crate) fn remap<F, V, T>(self, v: &mut V, f: F) -> Index<T>
+    pub(crate) fn remap<F, V, T, E>(self, v: &mut V, f: F) -> Result<Index<T>, E>
     where
-        F: Copy + Fn(&mut V, S) -> T,
+        F: Copy + Fn(&mut V, S) -> Result<T, E>,
     {
         use Index::*;
         match self {
-            Numeral(n) => Numeral(n),
-            Symbol(s) => Symbol(f(v, s)),
+            Numeral(n) => Ok(Numeral(n)),
+            Symbol(s) => Ok(Symbol(f(v, s)?)),
         }
     }
 }
@@ -86,39 +89,48 @@ pub enum Identifier<Symbol> {
 
 impl<S> Identifier<S> {
     /// Remap the symbols of an Identifier value.
-    pub(crate) fn remap<F, V, T>(self, v: &mut V, f: F) -> Identifier<T>
+    pub(crate) fn remap<F, V, T, E>(self, v: &mut V, f: F) -> Result<Identifier<T>, E>
     where
-        F: Copy + Fn(&mut V, S) -> T,
+        F: Copy + Fn(&mut V, S) -> Result<T, E>,
     {
         use Identifier::*;
         match self {
-            Simple { symbol } => Simple {
-                symbol: f(v, symbol),
-            },
-            Indexed { symbol, indices } => Indexed {
-                symbol: f(v, symbol),
-                indices: indices.into_iter().map(|i| i.remap(v, f)).collect(),
-            },
+            Simple { symbol } => Ok(Simple {
+                symbol: f(v, symbol)?,
+            }),
+            Indexed { symbol, indices } => Ok(Indexed {
+                symbol: f(v, symbol)?,
+                indices: indices
+                    .into_iter()
+                    .map(|i| i.remap(v, f))
+                    .collect::<Result<_, E>>()?,
+            }),
         }
     }
 }
 
 pub trait SortVisitor<Symbol> {
     type T;
+    type E;
 
-    fn visit_simple_sort(&mut self, identifier: Identifier<Symbol>) -> Self::T;
+    fn visit_simple_sort(&mut self, identifier: Identifier<Symbol>) -> Result<Self::T, Self::E>;
     fn visit_parameterized_sort(
         &mut self,
         identifier: Identifier<Symbol>,
         parameters: Vec<Self::T>,
-    ) -> Self::T;
+    ) -> Result<Self::T, Self::E>;
 }
 
 pub trait QualIdentifierVisitor<Identifier, Sort> {
     type T;
+    type E;
 
-    fn visit_simple_identifier(&mut self, identifier: Identifier) -> Self::T;
-    fn visit_sorted_identifier(&mut self, identifier: Identifier, sort: Sort) -> Self::T;
+    fn visit_simple_identifier(&mut self, identifier: Identifier) -> Result<Self::T, Self::E>;
+    fn visit_sorted_identifier(
+        &mut self,
+        identifier: Identifier,
+        sort: Sort,
+    ) -> Result<Self::T, Self::E>;
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
@@ -131,54 +143,80 @@ pub enum AttributeValue<Constant, Symbol, SExpr> {
 
 impl<T1, T2, T3> AttributeValue<T1, T2, T3> {
     /// Remap the generically-typed values of an AttributeValue.
-    pub(crate) fn remap<V, F1, F2, F3, R1, R2, R3>(
+    pub(crate) fn remap<V, F1, F2, F3, R1, R2, R3, E>(
         self,
         v: &mut V,
         f1: F1,
         f2: F2,
         f3: F3,
-    ) -> AttributeValue<R1, R2, R3>
+    ) -> Result<AttributeValue<R1, R2, R3>, E>
     where
-        F1: Fn(&mut V, T1) -> R1,
-        F2: Fn(&mut V, T2) -> R2,
-        F3: Fn(&mut V, T3) -> R3,
+        F1: Fn(&mut V, T1) -> Result<R1, E>,
+        F2: Fn(&mut V, T2) -> Result<R2, E>,
+        F3: Fn(&mut V, T3) -> Result<R3, E>,
     {
         use AttributeValue::*;
-        match self {
+        let value = match self {
             None => None,
-            Constant(value) => Constant(f1(v, value)),
-            Symbol(value) => Symbol(f2(v, value)),
-            SExpr(values) => SExpr(values.into_iter().map(|x| f3(v, x)).collect()),
-        }
+            Constant(value) => Constant(f1(v, value)?),
+            Symbol(value) => Symbol(f2(v, value)?),
+            SExpr(values) => SExpr(
+                values
+                    .into_iter()
+                    .map(|x| f3(v, x))
+                    .collect::<Result<_, E>>()?,
+            ),
+        };
+        Ok(value)
     }
 }
 
 pub trait TermVisitor<Constant, QualIdentifier, Keyword, SExpr, Symbol, Sort> {
     type T;
+    type E;
 
-    fn visit_constant(&mut self, constant: Constant) -> Self::T;
+    fn visit_constant(&mut self, constant: Constant) -> Result<Self::T, Self::E>;
 
-    fn visit_qual_identifier(&mut self, qual_identifier: QualIdentifier) -> Self::T;
+    fn visit_qual_identifier(
+        &mut self,
+        qual_identifier: QualIdentifier,
+    ) -> Result<Self::T, Self::E>;
 
     fn visit_application(
         &mut self,
         qual_identifier: QualIdentifier,
         arguments: Vec<Self::T>,
-    ) -> Self::T;
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_let(&mut self, var_bindings: Vec<(Symbol, Self::T)>, term: Self::T) -> Self::T;
+    fn visit_let(
+        &mut self,
+        var_bindings: Vec<(Symbol, Self::T)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_forall(&mut self, vars: Vec<(Symbol, Sort)>, term: Self::T) -> Self::T;
+    fn visit_forall(
+        &mut self,
+        vars: Vec<(Symbol, Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_exists(&mut self, vars: Vec<(Symbol, Sort)>, term: Self::T) -> Self::T;
+    fn visit_exists(
+        &mut self,
+        vars: Vec<(Symbol, Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_match(&mut self, term: Self::T, cases: Vec<(Vec<Symbol>, Self::T)>) -> Self::T;
+    fn visit_match(
+        &mut self,
+        term: Self::T,
+        cases: Vec<(Vec<Symbol>, Self::T)>,
+    ) -> Result<Self::T, Self::E>;
 
     fn visit_attributes(
         &mut self,
         term: Self::T,
         attributes: Vec<(Keyword, AttributeValue<Constant, Symbol, SExpr>)>,
-    ) -> Self::T;
+    ) -> Result<Self::T, Self::E>;
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
@@ -189,24 +227,24 @@ pub struct ConstructorDec<Symbol, Sort> {
 
 impl<T1, T2> ConstructorDec<T1, T2> {
     /// Remap the generically-typed values of a ConstructorDec value.
-    pub(crate) fn remap<V, F1, F2, R1, R2>(
+    pub(crate) fn remap<V, F1, F2, R1, R2, E>(
         self,
         v: &mut V,
         f1: F1,
         f2: F2,
-    ) -> ConstructorDec<R1, R2>
+    ) -> Result<ConstructorDec<R1, R2>, E>
     where
-        F1: Fn(&mut V, T1) -> R1,
-        F2: Fn(&mut V, T2) -> R2,
+        F1: Fn(&mut V, T1) -> Result<R1, E>,
+        F2: Fn(&mut V, T2) -> Result<R2, E>,
     {
-        ConstructorDec {
-            symbol: f1(v, self.symbol),
+        Ok(ConstructorDec {
+            symbol: f1(v, self.symbol)?,
             selectors: self
                 .selectors
                 .into_iter()
-                .map(|(s1, s2)| (f1(v, s1), f2(v, s2)))
-                .collect(),
-        }
+                .map(|(s1, s2)| Ok((f1(v, s1)?, f2(v, s2)?)))
+                .collect::<Result<_, E>>()?,
+        })
     }
 }
 
@@ -218,19 +256,28 @@ pub struct DatatypeDec<Symbol, Sort> {
 
 impl<T1, T2> DatatypeDec<T1, T2> {
     /// Remap the generically-typed values of a DatatypeDec value.
-    pub(crate) fn remap<V, F1, F2, R1, R2>(self, v: &mut V, f1: F1, f2: F2) -> DatatypeDec<R1, R2>
+    pub(crate) fn remap<V, F1, F2, R1, R2, E>(
+        self,
+        v: &mut V,
+        f1: F1,
+        f2: F2,
+    ) -> Result<DatatypeDec<R1, R2>, E>
     where
-        F1: Copy + Fn(&mut V, T1) -> R1,
-        F2: Copy + Fn(&mut V, T2) -> R2,
+        F1: Copy + Fn(&mut V, T1) -> Result<R1, E>,
+        F2: Copy + Fn(&mut V, T2) -> Result<R2, E>,
     {
-        DatatypeDec {
-            parameters: self.parameters.into_iter().map(|x| f1(v, x)).collect(),
+        Ok(DatatypeDec {
+            parameters: self
+                .parameters
+                .into_iter()
+                .map(|x| f1(v, x))
+                .collect::<Result<_, E>>()?,
             constructors: self
                 .constructors
                 .into_iter()
                 .map(|c| c.remap(v, f1, f2))
-                .collect(),
-        }
+                .collect::<Result<_, E>>()?,
+        })
     }
 }
 
@@ -243,119 +290,153 @@ pub struct FunctionDec<Symbol, Sort> {
 
 impl<T1, T2> FunctionDec<T1, T2> {
     /// Remap the generically-typed values of a FunctionDec value.
-    pub(crate) fn remap<V, F1, F2, R1, R2>(self, v: &mut V, f1: F1, f2: F2) -> FunctionDec<R1, R2>
+    pub(crate) fn remap<V, F1, F2, R1, R2, E>(
+        self,
+        v: &mut V,
+        f1: F1,
+        f2: F2,
+    ) -> Result<FunctionDec<R1, R2>, E>
     where
-        F1: Copy + Fn(&mut V, T1) -> R1,
-        F2: Copy + Fn(&mut V, T2) -> R2,
+        F1: Copy + Fn(&mut V, T1) -> Result<R1, E>,
+        F2: Copy + Fn(&mut V, T2) -> Result<R2, E>,
     {
-        FunctionDec {
-            name: f1(v, self.name),
+        Ok(FunctionDec {
+            name: f1(v, self.name)?,
             parameters: self
                 .parameters
                 .into_iter()
-                .map(|(s1, s2)| (f1(v, s1), f2(v, s2)))
-                .collect(),
-            result: f2(v, self.result),
-        }
+                .map(|(s1, s2)| Ok((f1(v, s1)?, f2(v, s2)?)))
+                .collect::<Result<_, E>>()?,
+            result: f2(v, self.result)?,
+        })
     }
 }
 
 pub trait CommandVisitor<Term, Symbol, Sort, Keyword, Constant, SExpr> {
     type T;
+    type E;
 
-    fn visit_assert(&mut self, term: Term) -> Self::T;
+    fn visit_assert(&mut self, term: Term) -> Result<Self::T, Self::E>;
 
-    fn visit_check_sat(&mut self) -> Self::T;
+    fn visit_check_sat(&mut self) -> Result<Self::T, Self::E>;
 
-    fn visit_check_sat_assuming(&mut self, literals: Vec<(Symbol, bool)>) -> Self::T;
+    fn visit_check_sat_assuming(
+        &mut self,
+        literals: Vec<(Symbol, bool)>,
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_declare_const(&mut self, symbol: Symbol, sort: Sort) -> Self::T;
+    fn visit_declare_const(&mut self, symbol: Symbol, sort: Sort) -> Result<Self::T, Self::E>;
 
     fn visit_declare_datatype(
         &mut self,
         symbol: Symbol,
         datatype: DatatypeDec<Symbol, Sort>,
-    ) -> Self::T;
+    ) -> Result<Self::T, Self::E>;
 
     fn visit_declare_datatypes(
         &mut self,
         datatypes: Vec<(Symbol, Numeral, DatatypeDec<Symbol, Sort>)>,
-    ) -> Self::T;
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_declare_fun(&mut self, symbol: Symbol, parameters: Vec<Sort>, sort: Sort) -> Self::T;
+    fn visit_declare_fun(
+        &mut self,
+        symbol: Symbol,
+        parameters: Vec<Sort>,
+        sort: Sort,
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_declare_sort(&mut self, symbol: Symbol, arity: Numeral) -> Self::T;
+    fn visit_declare_sort(&mut self, symbol: Symbol, arity: Numeral) -> Result<Self::T, Self::E>;
 
-    fn visit_define_fun(&mut self, sig: FunctionDec<Symbol, Sort>, term: Term) -> Self::T;
+    fn visit_define_fun(
+        &mut self,
+        sig: FunctionDec<Symbol, Sort>,
+        term: Term,
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_define_fun_rec(&mut self, sig: FunctionDec<Symbol, Sort>, term: Term) -> Self::T;
+    fn visit_define_fun_rec(
+        &mut self,
+        sig: FunctionDec<Symbol, Sort>,
+        term: Term,
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_define_funs_rec(&mut self, funs: Vec<(FunctionDec<Symbol, Sort>, Term)>) -> Self::T;
+    fn visit_define_funs_rec(
+        &mut self,
+        funs: Vec<(FunctionDec<Symbol, Sort>, Term)>,
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_define_sort(&mut self, symbol: Symbol, parameters: Vec<Symbol>, sort: Sort)
-        -> Self::T;
+    fn visit_define_sort(
+        &mut self,
+        symbol: Symbol,
+        parameters: Vec<Symbol>,
+        sort: Sort,
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_echo(&mut self, message: String) -> Self::T;
+    fn visit_echo(&mut self, message: String) -> Result<Self::T, Self::E>;
 
-    fn visit_exit(&mut self) -> Self::T;
+    fn visit_exit(&mut self) -> Result<Self::T, Self::E>;
 
-    fn visit_get_assertions(&mut self) -> Self::T;
+    fn visit_get_assertions(&mut self) -> Result<Self::T, Self::E>;
 
-    fn visit_get_assignment(&mut self) -> Self::T;
+    fn visit_get_assignment(&mut self) -> Result<Self::T, Self::E>;
 
-    fn visit_get_info(&mut self, flag: Keyword) -> Self::T;
+    fn visit_get_info(&mut self, flag: Keyword) -> Result<Self::T, Self::E>;
 
-    fn visit_get_model(&mut self) -> Self::T;
+    fn visit_get_model(&mut self) -> Result<Self::T, Self::E>;
 
-    fn visit_get_option(&mut self, keyword: Keyword) -> Self::T;
+    fn visit_get_option(&mut self, keyword: Keyword) -> Result<Self::T, Self::E>;
 
-    fn visit_get_proof(&mut self) -> Self::T;
+    fn visit_get_proof(&mut self) -> Result<Self::T, Self::E>;
 
-    fn visit_get_unsat_assumptions(&mut self) -> Self::T;
+    fn visit_get_unsat_assumptions(&mut self) -> Result<Self::T, Self::E>;
 
-    fn visit_get_unsat_core(&mut self) -> Self::T;
+    fn visit_get_unsat_core(&mut self) -> Result<Self::T, Self::E>;
 
-    fn visit_get_value(&mut self, terms: Vec<Term>) -> Self::T;
+    fn visit_get_value(&mut self, terms: Vec<Term>) -> Result<Self::T, Self::E>;
 
-    fn visit_pop(&mut self, level: Numeral) -> Self::T;
+    fn visit_pop(&mut self, level: Numeral) -> Result<Self::T, Self::E>;
 
-    fn visit_push(&mut self, level: Numeral) -> Self::T;
+    fn visit_push(&mut self, level: Numeral) -> Result<Self::T, Self::E>;
 
-    fn visit_reset(&mut self) -> Self::T;
+    fn visit_reset(&mut self) -> Result<Self::T, Self::E>;
 
-    fn visit_reset_assertions(&mut self) -> Self::T;
+    fn visit_reset_assertions(&mut self) -> Result<Self::T, Self::E>;
 
     fn visit_set_info(
         &mut self,
         keyword: Keyword,
         value: AttributeValue<Constant, Symbol, SExpr>,
-    ) -> Self::T;
+    ) -> Result<Self::T, Self::E>;
 
-    fn visit_set_logic(&mut self, symbol: Symbol) -> Self::T;
+    fn visit_set_logic(&mut self, symbol: Symbol) -> Result<Self::T, Self::E>;
 
     fn visit_set_option(
         &mut self,
         keyword: Keyword,
         value: AttributeValue<Constant, Symbol, SExpr>,
-    ) -> Self::T;
+    ) -> Result<Self::T, Self::E>;
 }
 
 /// A visitor for the entire SMT2 syntax.
 pub trait Smt2Visitor:
-    ConstantVisitor<T = <Self as Smt2Visitor>::Constant>
-    + SymbolVisitor<T = <Self as Smt2Visitor>::Symbol>
-    + KeywordVisitor<T = <Self as Smt2Visitor>::Keyword>
+    ConstantVisitor<T = <Self as Smt2Visitor>::Constant, E = <Self as Smt2Visitor>::Error>
+    + SymbolVisitor<T = <Self as Smt2Visitor>::Symbol, E = <Self as Smt2Visitor>::Error>
+    + KeywordVisitor<T = <Self as Smt2Visitor>::Keyword, E = <Self as Smt2Visitor>::Error>
     + SExprVisitor<
         <Self as Smt2Visitor>::Constant,
         <Self as Smt2Visitor>::Symbol,
         <Self as Smt2Visitor>::Keyword,
         T = <Self as Smt2Visitor>::SExpr,
+        E = <Self as Smt2Visitor>::Error,
     > + QualIdentifierVisitor<
         Identifier<<Self as Smt2Visitor>::Symbol>,
         <Self as Smt2Visitor>::Sort,
         T = <Self as Smt2Visitor>::QualIdentifier,
-    > + SortVisitor<<Self as Smt2Visitor>::Symbol, T = <Self as Smt2Visitor>::Sort>
-    + TermVisitor<
+        E = <Self as Smt2Visitor>::Error,
+    > + SortVisitor<
+        <Self as Smt2Visitor>::Symbol,
+        T = <Self as Smt2Visitor>::Sort,
+        E = <Self as Smt2Visitor>::Error,
+    > + TermVisitor<
         <Self as Smt2Visitor>::Constant,
         <Self as Smt2Visitor>::QualIdentifier,
         <Self as Smt2Visitor>::Keyword,
@@ -363,6 +444,7 @@ pub trait Smt2Visitor:
         <Self as Smt2Visitor>::Symbol,
         <Self as Smt2Visitor>::Sort,
         T = <Self as Smt2Visitor>::Term,
+        E = <Self as Smt2Visitor>::Error,
     > + CommandVisitor<
         <Self as Smt2Visitor>::Term,
         <Self as Smt2Visitor>::Symbol,
@@ -371,8 +453,10 @@ pub trait Smt2Visitor:
         <Self as Smt2Visitor>::Constant,
         <Self as Smt2Visitor>::SExpr,
         T = <Self as Smt2Visitor>::Command,
+        E = <Self as Smt2Visitor>::Error,
     >
 {
+    type Error;
     type Constant;
     type QualIdentifier;
     type Keyword;
@@ -381,6 +465,9 @@ pub trait Smt2Visitor:
     type Symbol;
     type Term;
     type Command;
+
+    fn syntax_error(&mut self) -> Self::Error;
+    fn parsing_error(&mut self, s: String) -> Self::Error;
 }
 
 impl<Symbol> std::fmt::Display for Index<Symbol>

--- a/smt2patch/Cargo.toml
+++ b/smt2patch/Cargo.toml
@@ -20,6 +20,7 @@ rand = "0.8.0"
 structopt = "0.3.12"
 smt2parser = { path = "../smt2parser", version = "0.4.1" }
 anyhow = "1.0.40"
+thiserror = "1.0.25"
 
 [[bin]]
 name = "smt2patch"

--- a/smt2patch/Cargo.toml
+++ b/smt2patch/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 [dependencies]
 rand = "0.8.0"
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.4.1" }
+smt2parser = { path = "../smt2parser", version = "0.5.0" }
 anyhow = "1.0.40"
 thiserror = "1.0.25"
 

--- a/smt2patch/src/lib.rs
+++ b/smt2patch/src/lib.rs
@@ -283,7 +283,8 @@ impl Patcher {
             discarded_options.insert(PRODUCE_UNSAT_CORES.to_string());
         }
         let rewriter = Rewriter::new(self.config.rewriter_config.clone(), discarded_options);
-        let mut stream = smt2parser::CommandStream::new(file, rewriter);
+        let mut stream =
+            smt2parser::CommandStream::new(file, rewriter, path.to_str().map(String::from));
         for result in &mut stream {
             match result {
                 Ok(command)
@@ -296,9 +297,9 @@ impl Patcher {
                 Ok(command) => {
                     self.script.push(command);
                 }
-                Err((_, Error::SkipCommand)) => {}
-                Err((position, error)) => {
-                    panic!("error: {}\n --> {}", error, position.location_in_file(path));
+                Err(Error::SkipCommand) => {}
+                Err(error) => {
+                    panic!("{}", error);
                 }
             }
         }

--- a/smt2proxy/Cargo.toml
+++ b/smt2proxy/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 [dependencies]
 rand = "0.8.0"
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.4.1" }
+smt2parser = { path = "../smt2parser", version = "0.5.0" }
 
 [[bin]]
 name = "smt2proxy"

--- a/smt2proxy/src/main.rs
+++ b/smt2proxy/src/main.rs
@@ -96,7 +96,7 @@ fn make_z3_args(options: &Options) -> Vec<String> {
 #[derive(Debug)]
 enum Event {
     Done,
-    Query(Box<Result<smt2parser::concrete::Command, (smt2parser::Position, smt2parser::Error)>>),
+    Query(Box<Result<smt2parser::concrete::Command, smt2parser::Error>>),
 }
 
 fn spawn_child_stream_logger<R>(
@@ -180,8 +180,7 @@ fn process_events(
                     Err(error) => {
                         if let Some(logger) = processor.logger() {
                             let mut f = logger.lock().unwrap();
-                            writeln!(f, "; Syntax error at {:?}", error)
-                                .expect("Failed to write to log file");
+                            writeln!(f, "; {}", error).expect("Failed to write to log file");
                         }
                         break;
                     }
@@ -237,7 +236,7 @@ fn main() {
     };
 
     // Send the input commands to the command processor.
-    let stream = smt2parser::CommandStream::new(input, smt2parser::concrete::SyntaxBuilder);
+    let stream = smt2parser::CommandStream::new(input, smt2parser::concrete::SyntaxBuilder, None);
     for result in stream {
         sender.send(Event::Query(Box::new(result))).unwrap();
     }

--- a/smt2proxy/src/main.rs
+++ b/smt2proxy/src/main.rs
@@ -96,7 +96,7 @@ fn make_z3_args(options: &Options) -> Vec<String> {
 #[derive(Debug)]
 enum Event {
     Done,
-    Query(Box<Result<smt2parser::concrete::Command, smt2parser::Position>>),
+    Query(Box<Result<smt2parser::concrete::Command, (smt2parser::Position, smt2parser::Error)>>),
 }
 
 fn spawn_child_stream_logger<R>(

--- a/z3tracer/Cargo.toml
+++ b/z3tracer/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 
 [dependencies]
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.4.1" }
+smt2parser = { path = "../smt2parser", version = "0.5.0" }
 thiserror = "1.0.24"
 once_cell = "1.7.2"
 


### PR DESCRIPTION
* Add results to all SMT2 visitors
* Including file path, column, and line directly in parsing errors
* Fix typo in parser regarding `get_assignment`