### PR TITLE
[smt2proxy] Support symbol normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "smt2proxy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "rand",
  "smt2parser",

--- a/smt2proxy/Cargo.toml
+++ b/smt2proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smt2proxy"
-version = "0.2.1"
+version = "0.2.2"
 description = "Binary tool to intercept and pre-process SMT2 commands"
 repository = "https://github.com/facebookincubator/smt2utils"
 documentation = "https://docs.rs/smt2proxy"

--- a/smt2proxy/src/main.rs
+++ b/smt2proxy/src/main.rs
@@ -16,6 +16,10 @@ struct Options {
     #[structopt(long)]
     smt2: bool,
 
+    /// Print Z3 version.
+    #[structopt(long)]
+    version: bool,
+
     /// Use stdin for Z3 input.
     #[structopt(long)]
     r#in: bool,
@@ -207,6 +211,14 @@ fn main() {
     let options = Options::from_iter(iter_args());
     let smt2proxy_normalize_symbols = options.smt2proxy_config.smt2proxy_normalize_symbols;
 
+    if options.version {
+        std::process::Command::new("z3")
+            .arg("-version")
+            .status()
+            .unwrap();
+        return;
+    }
+
     // Spawn the command processor in a separate thread.
     let (sender, receiver) = std::sync::mpsc::channel();
     let handler = {
@@ -230,7 +242,7 @@ fn main() {
         let path = options
             .file
             .or(path_opt)
-            .expect("Input file is required unless flag `-in` is passed.");
+            .expect("Input file is required unless flags `-in` or `-version` are passed.");
         let f = std::fs::File::open(&path)
             .unwrap_or_else(|_| panic!("Failed to open input file {:?}", path));
         Box::new(std::io::BufReader::new(f))


### PR DESCRIPTION
Enable normalization of symbols on the fly in the SMT2 proxy.

Note:
* Symbols are renamed `x0`, `x1`, etc disregarding their kind (type, function name),
* Names are assigned in order (no random shuffle yet).

Assuming that `smt2proxy` is in the PATH, the proxy can be tested from in the Diem repo like this:
```
SMT2PROXY_NORMALIZE_SYMBOLS=true SMT2PROXY_LOG_PATH=logs.smt2 BOOGIE_EXE=`which boogie` Z3_EXE=`which smt2proxy` \
cargo run --release -p move-prover -- --cores 1 -d language/diem-framework/modules -d language/move-stdlib/modules language/diem-framework/modules/DiemSystem.move

# Replay logs.
z3 logs.smt2
```

Note that `--cores 1` is important for the logs to be meaningful.