### PR TITLE
[smt2parser] handle push, pop, reset and respect kinds while renaming symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "smt2parser"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "fst",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "smt2proxy"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "rand",
  "smt2parser",

--- a/smt2parser/Cargo.toml
+++ b/smt2parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smt2parser"
-version = "0.5.1"
+version = "0.5.2"
 description = "Generic parser library for the SMT-LIB-2 format"
 repository = "https://github.com/facebookincubator/smt2utils"
 documentation = "https://docs.rs/smt2parser"

--- a/smt2parser/src/parser.rs
+++ b/smt2parser/src/parser.rs
@@ -42,7 +42,6 @@ pomelo! {
     %type identifier visitors::Identifier<T::Symbol>;
 
     %type bound_symbol T::Symbol;
-    %type bound_symbols Vec<T::Symbol>;
     %type fresh_symbol T::Symbol;
     %type fresh_symbols Vec<T::Symbol>;
     %type any_symbol T::Symbol;
@@ -97,8 +96,6 @@ pomelo! {
     any_symbol ::= Symbol(s) { extra.0.visit_any_symbol(s)? }
     keyword ::= Keyword(s) { extra.0.visit_keyword(s)? }
 
-    bound_symbols ::= bound_symbol(x) { vec![x] }
-    bound_symbols ::= bound_symbols(mut xs) bound_symbol(x) { xs.push(x); xs }
     fresh_symbols ::= fresh_symbol(x) { vec![x] }
     fresh_symbols ::= fresh_symbols(mut xs) fresh_symbol(x) { xs.push(x); xs }
     pattern_symbols ::= any_symbol(x) { vec![x] }

--- a/smt2parser/src/parser.rs
+++ b/smt2parser/src/parser.rs
@@ -93,7 +93,7 @@ pomelo! {
     %start_symbol command;
 
     bound_symbol ::= Symbol(s) { extra.0.visit_bound_symbol(s)? }
-    fresh_symbol ::= Symbol(s) { extra.0.visit_fresh_symbol(s)? }
+    fresh_symbol ::= Symbol(s) { extra.0.visit_fresh_symbol(s, crate::visitors::SymbolKind::Unknown)? }
     any_symbol ::= Symbol(s) { extra.0.visit_any_symbol(s)? }
     keyword ::= Keyword(s) { extra.0.visit_keyword(s)? }
 
@@ -207,7 +207,7 @@ pomelo! {
     prop_literals ::= prop_literals(mut xs) prop_literal(x) { xs.push(x); xs }
 
     // ⟨selector_dec⟩ ::= ( ⟨symbol⟩ ⟨sort⟩ )
-    selector_dec ::= LeftParen bound_symbol(x) sort(s) RightParen { (x, s) }
+    selector_dec ::= LeftParen fresh_symbol(x) sort(s) RightParen { (x, s) }
 
     selector_decs ::= selector_dec(x) { vec![x] }
     selector_decs ::= selector_decs(mut xs) selector_dec(x) { xs.push(x); xs }
@@ -318,7 +318,7 @@ pomelo! {
         }
     }
     //   ( define-sort ⟨symbol⟩ ( ⟨symbol⟩∗ ) ⟨sort⟩ )
-    command ::= LeftParen DefineSort fresh_symbol(x) LeftParen bound_symbols?(xs) RightParen sort(r) RightParen
+    command ::= LeftParen DefineSort fresh_symbol(x) LeftParen fresh_symbols?(xs) RightParen sort(r) RightParen
     {
         extra.0.visit_define_sort(x, xs.unwrap_or_else(Vec::new), r)?
     }

--- a/smt2parser/src/renaming.rs
+++ b/smt2parser/src/renaming.rs
@@ -6,7 +6,7 @@
 use crate::{
     concrete::*,
     rewriter::Rewriter,
-    visitors::{Identifier, Index, Smt2Visitor},
+    visitors::{Identifier, Index, Smt2Visitor, SymbolKind},
 };
 use num::ToPrimitive;
 use std::collections::{BTreeMap, BTreeSet};
@@ -186,7 +186,7 @@ where
         self.process_symbol(value)
     }
 
-    fn visit_fresh_symbol(&mut self, value: String) -> Result<Symbol, Error> {
+    fn visit_fresh_symbol(&mut self, value: String, _kind: SymbolKind) -> Result<Symbol, Error> {
         let s = Self::get_symbol(self.local_symbols.len());
         self.local_symbols.push(value);
         self.process_symbol(s)

--- a/smt2parser/src/renaming.rs
+++ b/smt2parser/src/renaming.rs
@@ -165,6 +165,15 @@ where
         self.process_command(value)
     }
 
+    fn visit_reset(&mut self) -> Result<Command, Error> {
+        self.local_symbols.clear();
+        self.global_symbols.clear();
+        self.bound_symbols.clear();
+        self.scopes.clear();
+        let value = self.visitor().visit_reset()?;
+        self.process_command(value)
+    }
+
     fn visit_bound_symbol(&mut self, value: String) -> Result<Symbol, Error> {
         let value = self
             .bound_symbols

--- a/smt2parser/src/renaming.rs
+++ b/smt2parser/src/renaming.rs
@@ -66,7 +66,7 @@ pub struct SymbolNormalizer<V> {
     bound_symbols: BTreeMap<String, Vec<usize>>,
 }
 
-const SYMBOL: &str = "x";
+const SYMBOL_PREFIX: &str = "x";
 
 impl<V> SymbolNormalizer<V> {
     pub fn new(visitor: V) -> Self {
@@ -79,11 +79,11 @@ impl<V> SymbolNormalizer<V> {
     }
 
     pub fn get_symbol(idx: usize) -> Symbol {
-        Symbol(format!("{}{}", SYMBOL, idx))
+        Symbol(format!("{}{}", SYMBOL_PREFIX, idx))
     }
 
     fn parse_symbol(s: &Symbol) -> usize {
-        str::parse(&s.0[SYMBOL.len()..]).expect("cannot parse symbol")
+        str::parse(&s.0[SYMBOL_PREFIX.len()..]).expect("cannot parse symbol")
     }
 
     /// Initial names of all local symbols that were renamed.

--- a/smt2parser/src/rewriter.rs
+++ b/smt2parser/src/rewriter.rs
@@ -8,7 +8,7 @@
 use crate::{
     visitors::{
         AttributeValue, CommandVisitor, ConstantVisitor, DatatypeDec, FunctionDec, Identifier,
-        KeywordVisitor, QualIdentifierVisitor, SExprVisitor, Smt2Visitor, SortVisitor,
+        KeywordVisitor, QualIdentifierVisitor, SExprVisitor, Smt2Visitor, SortVisitor, SymbolKind,
         SymbolVisitor, TermVisitor,
     },
     Binary, Decimal, Hexadecimal, Numeral, Position,
@@ -121,8 +121,9 @@ pub trait Rewriter {
     fn visit_fresh_symbol(
         &mut self,
         value: String,
+        kind: SymbolKind,
     ) -> Result<<Self::V as Smt2Visitor>::Symbol, Self::Error> {
-        let value = self.visitor().visit_fresh_symbol(value)?;
+        let value = self.visitor().visit_fresh_symbol(value, kind)?;
         self.process_symbol(value)
     }
 
@@ -546,8 +547,8 @@ where
     type T = V::Symbol;
     type E = R::Error;
 
-    fn visit_fresh_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
-        self.visit_fresh_symbol(value)
+    fn visit_fresh_symbol(&mut self, value: String, kind: SymbolKind) -> Result<Self::T, Self::E> {
+        self.visit_fresh_symbol(value, kind)
     }
 
     fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {

--- a/smt2parser/src/stats.rs
+++ b/smt2parser/src/stats.rs
@@ -7,7 +7,7 @@ use crate::{
     concrete::Error,
     visitors::{
         CommandVisitor, ConstantVisitor, KeywordVisitor, QualIdentifierVisitor, SExprVisitor,
-        Smt2Visitor, SortVisitor, SymbolVisitor, TermVisitor,
+        Smt2Visitor, SortVisitor, SymbolKind, SymbolVisitor, TermVisitor,
     },
     Binary, Decimal, Hexadecimal, Numeral, Position,
 };
@@ -165,7 +165,11 @@ impl SymbolVisitor for Smt2Counters {
     type T = ();
     type E = Error;
 
-    fn visit_fresh_symbol(&mut self, _value: String) -> Result<Self::T, Self::E> {
+    fn visit_fresh_symbol(
+        &mut self,
+        _value: String,
+        _kind: SymbolKind,
+    ) -> Result<Self::T, Self::E> {
         self.fresh_symbol_count += 1;
         Ok(())
     }

--- a/smt2parser/src/visitors.rs
+++ b/smt2parser/src/visitors.rs
@@ -18,13 +18,13 @@ pub trait ConstantVisitor {
     fn visit_string_constant(&mut self, value: String) -> Result<Self::T, Self::E>;
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Ord, Eq, Hash)]
 pub enum SymbolKind {
     Unknown,
     Variable,
-    Sort,
     Constant,
     Function,
+    Sort,
     Datatype,
     TypeVar,
     Constructor,

--- a/smt2patch/Cargo.toml
+++ b/smt2patch/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 [dependencies]
 rand = "0.8.0"
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.5.1" }
+smt2parser = { path = "../smt2parser", version = "0.5.2" }
 anyhow = "1.0.40"
 thiserror = "1.0.25"
 

--- a/smt2proxy/Cargo.toml
+++ b/smt2proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smt2proxy"
-version = "0.2.2"
+version = "0.2.3"
 description = "Binary tool to intercept and pre-process SMT2 commands"
 repository = "https://github.com/facebookincubator/smt2utils"
 documentation = "https://docs.rs/smt2proxy"

--- a/smt2proxy/Cargo.toml
+++ b/smt2proxy/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 [dependencies]
 rand = "0.8.0"
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.5.1" }
+smt2parser = { path = "../smt2parser", version = "0.5.2" }
 
 [[bin]]
 name = "smt2proxy"

--- a/z3tracer/Cargo.toml
+++ b/z3tracer/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 
 [dependencies]
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.5.1" }
+smt2parser = { path = "../smt2parser", version = "0.5.2" }
 thiserror = "1.0.24"
 once_cell = "1.7.2"
 


### PR DESCRIPTION
This allows reusing symbol names after a `(push)` or a `(reset)` and is generally more correct in case of name clashes with globals.

Additionally, we now use a different prefix for each symbol kind: "f" for functions, "T" for datatypes, etc. 