### PR TITLE
[smt2parser] add support for name randomization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "smt2parser"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "fst",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "rand 0.8.3",
  "smt2parser",
  "structopt",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "smt2proxy"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "rand 0.8.3",
  "smt2parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +61,16 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+dependencies = [
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "bumpalo"
@@ -131,6 +150,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -320,13 +345,24 @@ checksum = "d79238883cf0307100b90aba4a755d8051a3182305dfe7f649a1e9dc0517006f"
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.10.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -479,6 +515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce8738c9ddd350996cb8b8b718192851df960803764bcdaa3afb44a63b1ddb5c"
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "num"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +642,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b451513912d6b3440e443aa75a73ab22203afedc4a90df8526d008c0f86f7cb3"
 dependencies = [
  "rustc_version",
+]
+
+[[package]]
+name = "permutation_iterator"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55405179fe06e4e3820ddaf9f9b51cdff9e7496af9554acdb2b1921a86ca9cb"
+dependencies = [
+ "blake2-rfc",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -757,14 +809,37 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -774,7 +849,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -783,7 +867,16 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -792,7 +885,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -810,7 +903,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
  "redox_syscall",
 ]
 
@@ -916,9 +1009,12 @@ dependencies = [
  "fst",
  "itertools",
  "num",
+ "permutation_iterator",
  "pomelo",
+ "rand 0.8.3",
  "serde",
  "structopt",
+ "strum",
  "thiserror",
 ]
 
@@ -927,7 +1023,7 @@ name = "smt2patch"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "rand",
+ "rand 0.8.3",
  "smt2parser",
  "structopt",
  "thiserror",
@@ -937,7 +1033,7 @@ dependencies = [
 name = "smt2proxy"
 version = "0.2.3"
 dependencies = [
- "rand",
+ "rand 0.8.3",
  "smt2parser",
  "structopt",
 ]
@@ -976,6 +1072,27 @@ checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -1071,6 +1188,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/smt2parser/Cargo.toml
+++ b/smt2parser/Cargo.toml
@@ -23,6 +23,9 @@ fst = "0.4.5"
 serde = { version = "1.0.125", features = ["derive"] }
 itertools = "0.10.0"
 thiserror = "1.0.25"
+rand = "0.8.0"
+permutation_iterator = "0.1.2"
+strum = { version = "0.21", features = ["derive"] }
 
 [[bin]]
 name = "smt2bin"

--- a/smt2parser/Cargo.toml
+++ b/smt2parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smt2parser"
-version = "0.5.2"
+version = "0.6.0"
 description = "Generic parser library for the SMT-LIB-2 format"
 repository = "https://github.com/facebookincubator/smt2utils"
 documentation = "https://docs.rs/smt2parser"

--- a/smt2parser/src/visitors.rs
+++ b/smt2parser/src/visitors.rs
@@ -6,6 +6,7 @@
 use crate::{Binary, Decimal, Hexadecimal, Numeral};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use strum::EnumIter;
 
 pub trait ConstantVisitor {
     type T;
@@ -18,7 +19,7 @@ pub trait ConstantVisitor {
     fn visit_string_constant(&mut self, value: String) -> Result<Self::T, Self::E>;
 }
 
-#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Ord, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Ord, Eq, Hash, EnumIter)]
 pub enum SymbolKind {
     Unknown,
     Variable,

--- a/smt2patch/Cargo.toml
+++ b/smt2patch/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 [dependencies]
 rand = "0.8.0"
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.5.2" }
+smt2parser = { path = "../smt2parser", version = "0.6.0" }
 anyhow = "1.0.40"
 thiserror = "1.0.25"
 

--- a/smt2proxy/Cargo.toml
+++ b/smt2proxy/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 [dependencies]
 rand = "0.8.0"
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.5.2" }
+smt2parser = { path = "../smt2parser", version = "0.6.0" }
 strum = { version = "0.21" }
 
 [[bin]]

--- a/smt2proxy/Cargo.toml
+++ b/smt2proxy/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
 rand = "0.8.0"
 structopt = "0.3.12"
 smt2parser = { path = "../smt2parser", version = "0.5.2" }
+strum = { version = "0.21" }
 
 [[bin]]
 name = "smt2proxy"

--- a/smt2proxy/Cargo.toml
+++ b/smt2proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smt2proxy"
-version = "0.2.3"
+version = "0.2.4"
 description = "Binary tool to intercept and pre-process SMT2 commands"
 repository = "https://github.com/facebookincubator/smt2utils"
 documentation = "https://docs.rs/smt2proxy"

--- a/z3tracer/Cargo.toml
+++ b/z3tracer/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 
 [dependencies]
 structopt = "0.3.12"
-smt2parser = { path = "../smt2parser", version = "0.5.2" }
+smt2parser = { path = "../smt2parser", version = "0.6.0" }
 thiserror = "1.0.24"
 once_cell = "1.7.2"
 


### PR DESCRIPTION
Improve `renaming::SymbolNormalizer`:
* add a configuration object and support the randomization of variables (up to a maximum number of variables per kind, after which indices are just sequential).
* expose the number of distinct variables of each kind after normalization
* update the demo tool `smt2bin`
* update the tool `smt2proxy`

Examples:
```
# Demo tool in this repo:
cargo run --release -p smt2parser -- print --normalize-symbols --max-randomized-symbols 1024 --symbol-randomization-seed 5 path/to/file.smt2

# Proxy in the diem repo:
SMT2PROXY_NORMALIZE_SYMBOLS=true SMT2PROXY_LOG_PATH=logs.smt2 \
SMT2PROXY_MAX_RANDOMIZED_SYMBOLS=1024 SMT2PROXY_SYMBOL_RANDOMIZATION_SEED=1 \
BOOGIE_EXE=`which boogie` Z3_EXE=path/to/target/release/smt2proxy \
cargo run --release -p move-prover -- --cores 1 -d language/diem-framework/modules -d language/move-stdlib/modules language/diem-framework/modules/DiemSystem.move
```