### PR TITLE
WIP: Support parsing theories

### DIFF
--- a/smt2parser/src/concrete.rs
+++ b/smt2parser/src/concrete.rs
@@ -7,7 +7,7 @@ use crate::{
     lexer,
     visitors::{
         CommandVisitor, ConstantVisitor, KeywordVisitor, QualIdentifierVisitor, SExprVisitor,
-        Smt2Visitor, SortVisitor, SymbolKind, SymbolVisitor, TermVisitor,
+        Smt2Visitor, SortVisitor, SymbolKind, SymbolVisitor, TermVisitor, TheoryVisitor,
     },
     Binary, Decimal, Hexadecimal, Numeral, Position,
 };
@@ -194,6 +194,10 @@ pub enum Command<
         keyword: Keyword,
         value: AttributeValue<Constant, Symbol, SExpr>,
     },
+}
+
+pub struct Theory<Symbol = self::Symbol> {
+    name: Symbol,
 }
 
 /// An implementation of [`Smt2Visitor`] that returns concrete syntax values.
@@ -1045,6 +1049,15 @@ impl Command {
     }
 }
 
+impl TheoryVisitor<Symbol> for SyntaxBuilder {
+    type E = Error;
+    type T = Theory;
+
+    fn visit_theory(&mut self, name: Symbol) -> Result<Self::T, Self::E> {
+        Ok(Theory { name })
+    }
+}
+
 impl Smt2Visitor for SyntaxBuilder {
     type Error = Error;
     type Constant = Constant;
@@ -1055,6 +1068,7 @@ impl Smt2Visitor for SyntaxBuilder {
     type Symbol = Symbol;
     type Term = Term;
     type Command = Command;
+    type Theory = Theory;
 
     fn syntax_error(&mut self, position: crate::Position, s: String) -> Self::Error {
         Error::SyntaxError(position, s)

--- a/smt2parser/src/lexer.rs
+++ b/smt2parser/src/lexer.rs
@@ -79,6 +79,7 @@ const KEYWORDS: &[(&str, Token)] = {
         ("set-info", SetInfo),
         ("set-logic", SetLogic),
         ("set-option", SetOption),
+        ("theory", Theory),
     ]
 };
 

--- a/smt2parser/src/lib.rs
+++ b/smt2parser/src/lib.rs
@@ -53,6 +53,7 @@ pub type Binary = Vec<bool>;
 pub use concrete::Error;
 /// A position in the input.
 pub use lexer::Position;
+use parser::ParseResult;
 
 /// Parse the input data and return a stream of interpreted SMT2 commands
 pub struct CommandStream<R, T>
@@ -121,7 +122,8 @@ where
             }
             if unmatched_paren == 0 {
                 return match parser.end_of_input() {
-                    Ok((command, _)) => Some(Ok(command)),
+                    Ok((ParseResult::Command(command), _)) => Some(Ok(command)),
+                    Ok((ParseResult::Theory(res), _)) => unimplemented!(),
                     Err(err) => Some(Err(err)),
                 };
             }

--- a/smt2parser/src/rewriter.rs
+++ b/smt2parser/src/rewriter.rs
@@ -9,7 +9,7 @@ use crate::{
     visitors::{
         AttributeValue, CommandVisitor, ConstantVisitor, DatatypeDec, FunctionDec, Identifier,
         KeywordVisitor, QualIdentifierVisitor, SExprVisitor, Smt2Visitor, SortVisitor, SymbolKind,
-        SymbolVisitor, TermVisitor,
+        SymbolVisitor, TermVisitor, TheoryVisitor,
     },
     Binary, Decimal, Hexadecimal, Numeral, Position,
 };
@@ -720,6 +720,19 @@ where
     }
 }
 
+impl<R, V> TheoryVisitor<V::Symbol> for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type T = V::Theory;
+    type E = R::Error;
+
+    fn visit_theory(&mut self, name: V::Symbol) -> Result<Self::T, Self::E> {
+        self.visit_theory(name)
+    }
+}
+
 impl<R, V> CommandVisitor<V::Term, V::Symbol, V::Sort, V::Keyword, V::Constant, V::SExpr> for R
 where
     R: Rewriter<V = V>,
@@ -910,6 +923,7 @@ where
     type Symbol = V::Symbol;
     type Term = V::Term;
     type Command = V::Command;
+    type Theory = V::Theory;
 
     fn syntax_error(&mut self, pos: Position, s: String) -> Self::Error {
         self.visitor().syntax_error(pos, s).into()

--- a/smt2parser/src/stats.rs
+++ b/smt2parser/src/stats.rs
@@ -7,7 +7,7 @@ use crate::{
     concrete::Error,
     visitors::{
         CommandVisitor, ConstantVisitor, KeywordVisitor, QualIdentifierVisitor, SExprVisitor,
-        Smt2Visitor, SortVisitor, SymbolKind, SymbolVisitor, TermVisitor,
+        Smt2Visitor, SortVisitor, SymbolKind, SymbolVisitor, TermVisitor, TheoryVisitor,
     },
     Binary, Decimal, Hexadecimal, Numeral, Position,
 };
@@ -553,6 +553,15 @@ impl CommandVisitor<Term, Symbol, Sort, Keyword, Constant, SExpr> for Smt2Counte
     }
 }
 
+impl TheoryVisitor<Symbol> for Smt2Counters {
+    type E = Error;
+    type T = ();
+
+    fn visit_theory(&mut self, _name: Symbol) -> Result<(), Self::E> {
+        Ok(())
+    }
+}
+
 impl Smt2Visitor for Smt2Counters {
     type Error = Error;
     type Constant = ();
@@ -563,6 +572,7 @@ impl Smt2Visitor for Smt2Counters {
     type Symbol = ();
     type Term = Term;
     type Command = ();
+    type Theory = ();
 
     fn syntax_error(&mut self, position: Position, s: String) -> Self::Error {
         Error::SyntaxError(position, s)

--- a/smt2parser/src/visitors.rs
+++ b/smt2parser/src/visitors.rs
@@ -482,6 +482,10 @@ pub trait Smt2Visitor:
         <Self as Smt2Visitor>::SExpr,
         T = <Self as Smt2Visitor>::Command,
         E = <Self as Smt2Visitor>::Error,
+    > + TheoryVisitor<
+        <Self as Smt2Visitor>::Symbol,
+        T = <Self as Smt2Visitor>::Theory,
+        E = <Self as Smt2Visitor>::Error,
     >
 {
     type Error;
@@ -493,9 +497,18 @@ pub trait Smt2Visitor:
     type Symbol;
     type Term;
     type Command;
+    type Theory;
 
     fn syntax_error(&mut self, position: crate::Position, s: String) -> Self::Error;
     fn parsing_error(&mut self, position: crate::Position, s: String) -> Self::Error;
+}
+
+/// A visitor for the entire SMT2 syntax.
+pub trait TheoryVisitor<Symbol> {
+    type E;
+    type T;
+
+    fn visit_theory(&mut self, name: Symbol) -> Result<Self::T, Self::E>;
 }
 
 impl<Symbol> std::fmt::Display for Index<Symbol>


### PR DESCRIPTION
Hi, I wanted to take a crack at getting theory parsing working to fix https://github.com/facebookincubator/smt2utils/issues/15.

Before I went to the trouble of implementing all the parser rules and concrete syntax types, I wanted to validate the approach I'm taking.

Basically it amounts to:
- Parser returns an enum `ParseResult` which could be either a `Command` or a `Theory`. (currently, no modesetting is done, we rely on upstream consumers like CommandStream, to provide errors if the parser returns an unexpected result)
- Extend `SmtVisitor` with `TheoryVisitor`. I'm not sure I like this because I imagine there are a lot of tools that will only operate on `Command`s and not on `Theory`s but it seemed the least invasive choice. I would welcome some guidance on this point.